### PR TITLE
Fixes a nasty vanilla bug

### DIFF
--- a/Integrations/URS/reportscreen.lua
+++ b/Integrations/URS/reportscreen.lua
@@ -464,7 +464,7 @@ function GetData()
 
 			if pDeals ~= nil then
 				for i,pDeal in ipairs(pDeals) do
-					if pDeal:IsValid() then
+					--if pDeal:IsValid() then --!! ARISTOS: Bug??? deal:IsValid() not always returns true even if the deal IS valid!!!
 						-- Add outgoing gold deals
 						local pOutgoingDeal :table	= pDeal:FindItemsByType(DealItemTypes.GOLD, DealItemSubTypes.NONE, playerID);
 						if pOutgoingDeal ~= nil then
@@ -550,7 +550,7 @@ function GetData()
 								end
 							end
 						end
-					end
+					--end --!! ARISTOS: Bug??? deal:IsValid() not always returns true even if the deal IS valid!!!
 				end
 			end
 


### PR DESCRIPTION
The function deal:IsValid() is not trustworthy. It does not always return the expected value, and is most noticeable with some deals for which the function returns False even if the deal is clearly valid and existent. This would manifest as a luxury resource in the Resources tab of the Report Screen identified as coming from "Great People" when in fact the source is another civ. Once the test condition IF deal:IsValid() is removed from the iterator, the resource is correctly identified from the deal item. You can test it with the original file and then with this correction to see the difference.

I corrected the same bug in DiplomacyDealView.lua for the new addon.