### PR TITLE
Implementing rollup diplomacy ribbon banners

### DIFF
--- a/Assets/UI/diplomacyribbon.lua
+++ b/Assets/UI/diplomacyribbon.lua
@@ -43,6 +43,21 @@ local m_kLeaderIM			:table = InstanceManager:new("LeaderInstance", "LeaderContai
 local m_PartialScreenHookBar: table;	-- = ContextPtr:LookUpControl( "/InGame/PartialScreenHooks/LaunchBacking" );
 local m_LaunchBar			: table;	-- = ContextPtr:LookUpControl( "/InGame/LaunchBar/LaunchBacking" );
 
+--CQUI Members
+local CQUI_DefaultHiddenBanners = false;
+local CQUI_LeaderBannerToggle = {}; --Contains a value determining if the given leader ID should have it's diplo banner expanded or not (nil is the default state, which is off)
+
+function CQUI_ExpandBanner(instance)
+	instance.CQUI_BannerRollupAnim:SetToBeginning();
+	instance.CQUI_BannerRollupAnim:Play();
+end
+function CQUI_CollapseBanner(instance)
+	if(not instance.CQUI_BannerRollupAnim:IsReversing()) then
+		instance.CQUI_BannerRollupAnim:Stop();
+		instance.CQUI_BannerRollupAnim:Reverse();
+	end
+end
+
 -- ===========================================================================
 --	Cleanup leaders
 -- ===========================================================================
@@ -116,6 +131,22 @@ function AddLeader(iconName : string, playerID : number, isUniqueLeader: boolean
 	-- Register the click handler
 	instance.Button:RegisterCallback( Mouse.eLClick, function() OnLeaderClicked(playerID); end );
 	instance.Button:RegisterCallback( Mouse.eRClick, function() OnLeaderRightClicked(playerID); end );
+	--CQUI banner rollup anims
+	instance.Button:RegisterCallback( Mouse.eMouseEnter, function()
+		if(not CQUI_LeaderBannerToggle[playerID]) then
+			CQUI_ExpandBanner(instance);
+		end
+	end);
+	instance.CQUI_ScoreDisplayToggle:RegisterCallback( Mouse.eMouseExit, function()
+		if(not CQUI_LeaderBannerToggle[playerID]) then
+			CQUI_CollapseBanner(instance);
+		end
+	end);
+	instance.CQUI_ScoreDisplayToggle:RegisterCallback(Mouse.eLClick, function()
+		if(CQUI_LeaderBannerToggle[playerID] == nil) then
+			CQUI_LeaderBannerToggle[playerID] = true;
+		else CQUI_LeaderBannerToggle[playerID] = not CQUI_LeaderBannerToggle[playerID]; end
+	end);
 
 	local bShowRelationshipIcon:boolean = false;
 	local localPlayerID:number = Game.GetLocalPlayer();

--- a/Assets/UI/diplomacyribbon.xml
+++ b/Assets/UI/diplomacyribbon.xml
@@ -43,26 +43,31 @@
   <!-- ==================================================================	-->
   <Instance Name="LeaderInstance">
       <SlideAnim ID="LeaderContainer" Size="60,120" Offset="0,0" Begin="0,0" EndOffset="0,20" Cycle="Once" Stopped="1">
-        <Grid Style="EnhancedToolTip" Size="parent,parent" Color="255,200,100,255" InnerPadding="10,5">
-          <Stack ID="CQUI_ScoreDisplayStack" Anchor="C,T" StackGrowth="Bottom" StackPadding="4" >
-            <Button ID="Button" Size="parent,52">
-              <Image Texture="Controls_CircleBacking45" Size="51,51" Anchor="C,C" Offset="0,1"/>
-              <Image Anchor="C,C" ID="YouIndicator" Hidden="1" Size="55,53" Texture="Diplomacy_YouIndicator45"/>
-              <Image ID="Portrait" Anchor="C,C" Size="45,45" Texture="Leaders45" />
-              <Image ID="TeamRibbon" Anchor="C,B" Offset="0,-8" Texture="TeamRibbon53" Size="53,53"/>
-              <Button ID="Relationship" StretchMode="None" Style="DiplomacyRelationshipPips" Anchor="L,B" Disabled="1" ConsumeMouse="0"/>
-            </Button>
-            <Label  ID="CQUI_ScoreOverall"                Anchor="L,B" Offset="0,0"     Style="CityPanelNumSmall"   String="-" />
-            <Label  ID="CQUI_ScienceRate"                Anchor="L,B" Offset="0,0"     Style="CityPanelCBScience"   String="Sci" />
-            <Label  ID="CQUI_MilitaryStrength"               Anchor="L,B" Offset="0,0"     Style="CityPanelCBProduction"   String="Mil" />
-          </Stack>
-          <Image ID="CivIndicator" Anchor="R,T" Texture="CircleBacking22" Size="22,22" Offset="-5,-2" Hidden="1">
-            <Image ID="CivIcon" Anchor="C,C" Texture="CivSymbols22" Size="22,22"/>
-          </Image>
-  				<AlphaAnim ID="ChatIndicatorFade" Cycle="Once" AlphaBegin="0.0" AlphaEnd="1.0" Speed="3" Stopped="1">
-  					<Image ID="ChatIndicator" Hidden="0" Offset="35,0" Size="22,22" Texture="DiploRibbon_TypingIndicator"/>
-  				</AlphaAnim>
-        </Grid>
+        <Button ID="CQUI_ScoreDisplayToggle" Size="parent,parent">
+          <SlideAnim ID="CQUI_BannerRollupAnim" Begin="0,-120" End="0,0" Cycle="Once" Function="OutQuint" Speed="2" Stopped="1">
+            <Grid ID="CQUI_ScoreDisplayContainer" Style="EnhancedToolTip" Size="parent,parent" Color="255,200,100,255" InnerPadding="10,5">
+              <Stack ID="CQUI_ScoreDisplayStack" Anchor="C,T" StackGrowth="Bottom" StackPadding="4" >
+                <Grid Size="parent,52" Alpha="0"/> <!-- Occupies the space of the button as a placeholder while the button renders on top of the stack instead of inside it. This is done to animate the score stack seperately -->
+                <Label  ID="CQUI_ScoreOverall"                Anchor="L,B" Offset="0,0"     Style="CityPanelNumSmall"   String="-" />
+                <Label  ID="CQUI_ScienceRate"                Anchor="L,B" Offset="0,0"     Style="CityPanelCBScience"   String="Sci" />
+                <Label  ID="CQUI_MilitaryStrength"               Anchor="L,B" Offset="0,0"     Style="CityPanelCBProduction"   String="Mil" />
+              </Stack>
+              <Image ID="CivIndicator" Anchor="R,T" Texture="CircleBacking22" Size="22,22" Offset="-5,-2" Hidden="1">
+                <Image ID="CivIcon" Anchor="C,C" Texture="CivSymbols22" Size="22,22"/>
+              </Image>
+              <AlphaAnim ID="ChatIndicatorFade" Cycle="Once" AlphaBegin="0.0" AlphaEnd="1.0" Speed="3" Stopped="1">
+                <Image ID="ChatIndicator" Hidden="0" Offset="35,0" Size="22,22" Texture="DiploRibbon_TypingIndicator"/>
+              </AlphaAnim>
+            </Grid>
+          </SlideAnim>
+        </Button>
+        <Button ID="Button" Size="parent,52">
+          <Image Texture="Controls_CircleBacking45" Size="51,51" Anchor="C,C" Offset="0,1"/>
+          <Image Anchor="C,C" ID="YouIndicator" Hidden="1" Size="55,53" Texture="Diplomacy_YouIndicator45"/>
+          <Image ID="Portrait" Anchor="C,C" Size="45,45" Texture="Leaders45" />
+          <Image ID="TeamRibbon" Anchor="C,B" Offset="0,-8" Texture="TeamRibbon53" Size="53,53"/>
+          <Button ID="Relationship" StretchMode="None" Style="DiplomacyRelationshipPips" Anchor="L,B" Disabled="1" ConsumeMouse="0"/>
+        </Button>
       </SlideAnim>
   </Instance>
 


### PR DESCRIPTION
This PR adds a method to hide individual diplomacy banners. It achieves this by having the banners able to be toggled from a hidden state to an active one, while also being able to "peek" the banner by mousing over the corresponding portrait while hidden

Currently, the banners start hidden by default and unroll when you mouse
over the diplomacy ribbon portraits. Clicking the banners stickies them
open.

TODO:
  * Better indication that the banners are clickable (some kind of
  highlighting on mouseover?)
  * An option to invert the default state to opened (I plan to make this
  option default to true, to match the current behavior of the diplomacy
  ribbon banners)
  * Persisting the states of the banners on save/reload