### PR TITLE
Implement tutorial options from #134

### DIFF
--- a/Assets/UI/Panels/unitpanel.lua
+++ b/Assets/UI/Panels/unitpanel.lua
@@ -83,6 +83,17 @@ local pSpyInfo = GameInfo.Units["UNIT_SPY"];
 local m_AttackHotkeyId      = Input.GetActionId("Attack");
 local m_DeleteHotkeyId      = Input.GetActionId("DeleteUnit");
 
+
+--CQUI Members
+local CQUI_ImprovementTutorial = true;
+local CQUI_AutoExpandUnitActions = false;
+
+function CQUI_OnSettingsUpdate()
+  CQUI_AutoExpandUnitActions = GameConfiguration.GetValue("CQUI_AutoExpandUnitActions");
+  CQUI_ImprovementTutorial = GameConfiguration.GetValue("CQUI_ImprovementTutorial");
+  OnRefresh();
+end
+
 -- ===========================================================================
 --  FUNCTIONS
 -- ===========================================================================
@@ -786,9 +797,8 @@ function View(data)
     Controls.RecommendedActionButton:ReprocessAnchoring();
     Controls.RecommendedActionIcon:ReprocessAnchoring();
 
-    bestBuildAction = nil;
     Controls.RecommendedActionFrame:SetHide( bestBuildAction == nil );
-    if ( bestBuildAction ~= nil ) then
+    if ( bestBuildAction ~= nil and CQUI_ImprovementTutorial) then
       Controls.RecommendedActionButton:SetHide(false);
       Controls.BuildActionsPanel:SetSizeY( buildStackHeight + 20 + BUILD_PANEL_ART_PADDING_Y);
       Controls.BuildActionsStack:SetOffsetY(26);
@@ -2085,7 +2095,7 @@ function Refresh(player, unitId)
     if(unit ~= nil) then
       ReadUnitData( unit, numUnits );
       --CQUI auto-expando
-      if(GameConfiguration.GetValue("CQUI_AutoExpandUnitActions")) then
+      if(CQUI_AutoExpandUnitActions) then
         local isHidden:boolean = Controls.SecondaryActionsStack:IsHidden();
         if isHidden then
           Controls.SecondaryActionsStack:SetHide(false);
@@ -3718,6 +3728,9 @@ function Initialize()
   LuaEvents.UnitFlagManager_PointerEntered.Add(   OnUnitFlagPointerEntered );
   LuaEvents.UnitFlagManager_PointerExited.Add(    OnUnitFlagPointerExited );
   LuaEvents.PlayerChange_Close.Add(         OnPlayerChangeClose );
+
+  --CQUI Events
+  LuaEvents.CQUI_SettingsUpdate.Add(CQUI_OnSettingsUpdate);
 
   -- Popup setup
   m_kPopupDialog = PopupDialog:new( "UnitPanelPopup" );

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -270,6 +270,7 @@ function Initialize()
     {Controls.CityviewTab, Controls.CityviewOptions},
     {Controls.LensesTab, Controls.LensesOptions},
     {Controls.UnitsTab, Controls.UnitsOptions},
+    {Controls.TutorialsTab, Controls.TutorialsOptions},
     {Controls.HiddenTab, Controls.HiddenOptions}
   };
   for i, tab in ipairs(m_tabs) do
@@ -304,6 +305,10 @@ function Initialize()
   PopulateCheckBox(Controls.AutoExpandUnitActionsCheckbox, "CQUI_AutoExpandUnitActions");
   PopulateCheckBox(Controls.AlwaysOpenTechTreesCheckbox, "CQUI_AlwaysOpenTechTrees");
   PopulateCheckBox(Controls.SmartWorkIconCheckbox, "CQUI_SmartWorkIcon", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTWORKICON_TOOLTIP"));
+  PopulateCheckBox(Controls.ImprovementTutorialCheckbox, "CQUI_ImprovementTutorial");
+  PopulateCheckBox(Controls.TechTutorialCheckbox, "CQUI_TechTutorial");
+  PopulateCheckBox(Controls.ProductionTutorialCheckbox, "CQUI_ProductionTutorial");
+  PopulateCheckBox(Controls.CityTutorialCheckbox, "CQUI_CityTutorial");
 
   PopulateSlider(Controls.ProductionItemHeightSlider, Controls.ProductionItemHeightText, "CQUI_ProductionItemHeight", ProductionItemHeightConverter);
   PopulateSlider(Controls.MinimapSizeSlider, Controls.MinimapSizeText, "CQUI_MinimapSize", MinimapSizeConverter);

--- a/Assets/cqui_settingselement.xml
+++ b/Assets/cqui_settingselement.xml
@@ -21,6 +21,7 @@
               <GridButton ID="BindingsTab" Style="ShellTabSmall" String="{LOC_CQUI_BINDINGS:upper}" Size="200,32"/>
               <GridButton ID="GossipTab" Style="ShellTabSmall" String="{LOC_CQUI_GOSSIP:upper}" Size="200,32"/>
               <GridButton ID="LensesTab" Style="ShellTabSmall" String="{LOC_CQUI_LENSES:upper}" Size="200,32"/>
+              <GridButton ID="TutorialsTab" Style="ShellTabSmall" String="{LOC_CQUI_TUTORIALS:upper}" Size="200,32"/>
               <GridButton ID="HiddenTab" Style="ShellTabSmall" String="{LOC_CQUI_GENERAL_HIDDEN:upper}" Size="200,32" Hidden="1"/>
             </Stack>
           </Grid>
@@ -381,6 +382,22 @@
           </Stack>
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <GridButton ID="AutoapplyScoutLensCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_LENSES_AUTOAPPLYSCOUTLENS"/>
+          </Stack>
+        </Stack>
+      </Container>
+      <Container ID="TutorialsOptions" Size="parent,parent" Hidden="1">
+        <Stack Anchor="C,T" StackGrowth="Down" Padding="5" Offset="0,50">
+          <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+            <GridButton ID="ImprovementTutorialCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_TUTORIALS_IMPROVEMENTS"/>
+          </Stack>
+          <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+            <GridButton ID="TechTutorialCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_TUTORIALS_TECHS"/>
+          </Stack>
+          <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+            <GridButton ID="ProductionTutorialCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_TUTORIALS_PRODUCTION"/>
+          </Stack>
+          <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+            <GridButton ID="CityTutorialCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_TUTORIALS_CITY"/>
           </Stack>
         </Stack>
       </Container>


### PR DESCRIPTION
Resolves #134 when finished

Objectives:
  - [x] Settings menu entries
  - [x] Builder tutorial option
  - [ ] Localization text for settings menu
  - [ ] Implement tech tutorial option
    - [ ] Implement actually removing the existing tutorial info from the slide-out tech/civic panels
  - [ ] Implement production item tutorial option
  - [ ] Implement city panel tutorial option