### PR TITLE
Filter displayed resource types in Resources tab

### DIFF
--- a/Integrations/URS/reportscreen.lua
+++ b/Integrations/URS/reportscreen.lua
@@ -1372,48 +1372,56 @@ function ViewResourcesPage()
 
 	for eResourceType,kSingleResourceData in pairs(m_kResourceData) do
 
-		local instance:table = NewCollapsibleGroupInstance();
+		--!!ARISTOS: Only display list of selected resource types, according to checkboxes
+		if (kSingleResourceData.IsStrategic and Controls.StrategicCheckbox:IsSelected()) or
+			(kSingleResourceData.IsLuxury and Controls.LuxuryCheckbox:IsSelected()) or
+			(kSingleResourceData.IsBonus and Controls.BonusCheckbox:IsSelected()) then
+		
+			local instance:table = NewCollapsibleGroupInstance();
 
-		local kResource :table = GameInfo.Resources[eResourceType];
-		instance.RowHeaderButton:SetText(  kSingleResourceData.Icon..Locale.Lookup( kResource.Name ) );
-		instance.RowHeaderLabel:SetHide( true )
+			local kResource :table = GameInfo.Resources[eResourceType];
+			instance.RowHeaderButton:SetText(  kSingleResourceData.Icon..Locale.Lookup( kResource.Name ) );
+			instance.RowHeaderLabel:SetHide( true )
 
-		local pHeaderInstance:table = {};
-		ContextPtr:BuildInstanceForControl( "ResourcesHeaderInstance", pHeaderInstance, instance.ContentStack ) ;
+			local pHeaderInstance:table = {};
+			ContextPtr:BuildInstanceForControl( "ResourcesHeaderInstance", pHeaderInstance, instance.ContentStack ) ;
 
-		local kResourceEntries:table = kSingleResourceData.EntryList;
-		for i,kEntry in ipairs(kResourceEntries) do
-			local pEntryInstance:table = {};
-			ContextPtr:BuildInstanceForControl( "ResourcesEntryInstance", pEntryInstance, instance.ContentStack ) ;
-			pEntryInstance.CityName:SetText( Locale.Lookup(kEntry.EntryText) );
-			pEntryInstance.Control:SetText( Locale.Lookup(kEntry.ControlText) );
-			pEntryInstance.Amount:SetText( (kEntry.Amount<=0) and tostring(kEntry.Amount) or "+"..tostring(kEntry.Amount) );
-		end
-
-		local pFooterInstance:table = {};
-		ContextPtr:BuildInstanceForControl( "ResourcesFooterInstance", pFooterInstance, instance.ContentStack ) ;
-		pFooterInstance.Amount:SetText( tostring(kSingleResourceData.Total) );
-
-		-- Show how many of this resource are being allocated to what cities
-		local localPlayerID = Game.GetLocalPlayer();
-		local localPlayer = Players[localPlayerID];
-		local citiesProvidedTo: table = localPlayer:GetResources():GetResourceAllocationCities(GameInfo.Resources[kResource.ResourceType].Index);
-		local numCitiesProvidingTo: number = table.count(citiesProvidedTo);
-		if (numCitiesProvidingTo > 0) then
-			pFooterInstance.AmenitiesContainer:SetHide(false);
-			pFooterInstance.Amenities:SetText("[ICON_Amenities][ICON_GoingTo]"..numCitiesProvidingTo.." "..Locale.Lookup("LOC_PEDIA_CONCEPTS_PAGEGROUP_CITIES_NAME"));
-			local amenitiesTooltip: string = "";
-			local playerCities = localPlayer:GetCities();
-			for i,city in ipairs(citiesProvidedTo) do
-				local cityName = Locale.Lookup(playerCities:FindID(city.CityID):GetName());
-				if i ~=1 then
-					amenitiesTooltip = amenitiesTooltip.. "[NEWLINE]";
-				end
-				amenitiesTooltip = amenitiesTooltip.. city.AllocationAmount.." [ICON_".. kResource.ResourceType.."] [Icon_GoingTo] " ..cityName;
+			local kResourceEntries:table = kSingleResourceData.EntryList;
+			for i,kEntry in ipairs(kResourceEntries) do
+				local pEntryInstance:table = {};
+				ContextPtr:BuildInstanceForControl( "ResourcesEntryInstance", pEntryInstance, instance.ContentStack ) ;
+				pEntryInstance.CityName:SetText( Locale.Lookup(kEntry.EntryText) );
+				pEntryInstance.Control:SetText( Locale.Lookup(kEntry.ControlText) );
+				pEntryInstance.Amount:SetText( (kEntry.Amount<=0) and tostring(kEntry.Amount) or "+"..tostring(kEntry.Amount) );
 			end
-			pFooterInstance.Amenities:SetToolTipString(amenitiesTooltip);
-		else
-			pFooterInstance.AmenitiesContainer:SetHide(true);
+
+			local pFooterInstance:table = {};
+			ContextPtr:BuildInstanceForControl( "ResourcesFooterInstance", pFooterInstance, instance.ContentStack ) ;
+			pFooterInstance.Amount:SetText( tostring(kSingleResourceData.Total) );
+
+			-- Show how many of this resource are being allocated to what cities
+			local localPlayerID = Game.GetLocalPlayer();
+			local localPlayer = Players[localPlayerID];
+			local citiesProvidedTo: table = localPlayer:GetResources():GetResourceAllocationCities(GameInfo.Resources[kResource.ResourceType].Index);
+			local numCitiesProvidingTo: number = table.count(citiesProvidedTo);
+			if (numCitiesProvidingTo > 0) then
+				pFooterInstance.AmenitiesContainer:SetHide(false);
+				pFooterInstance.Amenities:SetText("[ICON_Amenities][ICON_GoingTo]"..numCitiesProvidingTo.." "..Locale.Lookup("LOC_PEDIA_CONCEPTS_PAGEGROUP_CITIES_NAME"));
+				local amenitiesTooltip: string = "";
+				local playerCities = localPlayer:GetCities();
+				for i,city in ipairs(citiesProvidedTo) do
+					local cityName = Locale.Lookup(playerCities:FindID(city.CityID):GetName());
+					if i ~=1 then
+						amenitiesTooltip = amenitiesTooltip.. "[NEWLINE]";
+					end
+					amenitiesTooltip = amenitiesTooltip.. city.AllocationAmount.." [ICON_".. kResource.ResourceType.."] [Icon_GoingTo] " ..cityName;
+				end
+				pFooterInstance.Amenities:SetToolTipString(amenitiesTooltip);
+			else
+				pFooterInstance.AmenitiesContainer:SetHide(true);
+			end
+			SetGroupCollapsePadding(instance, pFooterInstance.Top:GetSizeY() );
+			RealizeGroup( instance );
 		end
 
 		if kSingleResourceData.IsStrategic then
@@ -1426,8 +1434,8 @@ function ViewResourcesPage()
 			table.insert(kBonuses, kSingleResourceData.Icon .. tostring( kSingleResourceData.Total ) );
 		end
 
-		SetGroupCollapsePadding(instance, pFooterInstance.Top:GetSizeY() );
-		RealizeGroup( instance );
+		--SetGroupCollapsePadding(instance, pFooterInstance.Top:GetSizeY() );
+		--RealizeGroup( instance );
 	end
 
 	m_strategicResourcesIM:ResetInstances();
@@ -2092,6 +2100,27 @@ function OnToggleCityBuildings()
 	ViewYieldsPage();
 end
 
+-- ===========================================================================
+--ARISTOS: Toggles for different resources in Resources tab
+function OnToggleStrategic()
+	local isChecked = Controls.StrategicCheckbox:IsSelected();
+	Controls.StrategicCheckbox:SetSelected( not isChecked );
+	ViewResourcesPage();
+end
+
+function OnToggleLuxury()
+	local isChecked = Controls.LuxuryCheckbox:IsSelected();
+	Controls.LuxuryCheckbox:SetSelected( not isChecked );
+	ViewResourcesPage();
+end
+
+function OnToggleBonus()
+	local isChecked = Controls.BonusCheckbox:IsSelected();
+	Controls.BonusCheckbox:SetSelected( not isChecked );
+	ViewResourcesPage();
+end
+--ARISTOS: End resources toggle
+
 function Initialize()
 
 	Resize();
@@ -2123,6 +2152,19 @@ function Initialize()
 
 	Controls.CityBuildingsCheckbox:RegisterCallback( Mouse.eLClick, OnToggleCityBuildings )
 	Controls.CityBuildingsCheckbox:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end )
+	
+	--ARISTOS: Resources toggle
+	Controls.LuxuryCheckbox:RegisterCallback( Mouse.eLClick, OnToggleLuxury );
+	Controls.LuxuryCheckbox:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end );
+	Controls.LuxuryCheckbox:SetSelected( true );
+	
+	Controls.StrategicCheckbox:RegisterCallback( Mouse.eLClick, OnToggleStrategic );
+	Controls.StrategicCheckbox:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end );
+	Controls.StrategicCheckbox:SetSelected( true );
+	
+	Controls.BonusCheckbox:RegisterCallback( Mouse.eLClick, OnToggleBonus );
+	Controls.BonusCheckbox:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end );
+	Controls.BonusCheckbox:SetSelected( true );
 
 	-- Events
 	LuaEvents.TopPanel_OpenReportsScreen.Add( OnTopOpenReportsScreen );

--- a/Integrations/URS/reportscreen.xml
+++ b/Integrations/URS/reportscreen.xml
@@ -129,15 +129,18 @@
 			<Grid																	Anchor="C,T"	Offset="0,0"		Size="parent,8"							Style="Divider3Grid" />
 			<Image																Anchor="C,B"	Offset="0,2"		Size="parent,parent"				Texture="Controls_Gradient" Color="255,255,255,32">
 				<Grid			ID="StrategicGrid"											Offset="5,10"		Size="parent-515,40"				Style="SubContainer4"				Color="36,50,62,255" InnerPadding="2,2">
-					<Label																					Offset="5,0"																Style="ReportResourceText"	String="LOC_HUD_REPORTS_STRATEGICS" />
+					<!-- <Label																					Offset="5,0"																Style="ReportResourceText"	String="LOC_HUD_REPORTS_STRATEGICS" /> -->
+					<GridButton   ID="StrategicCheckbox"  Anchor="L,C" Style="CheckBoxControl" String="LOC_HUD_REPORTS_STRATEGICS" Size="120,25" Offset="5,0" Hidden="0" />
 					<Stack	ID="StrategicResources"		Anchor="L,C"	Offset="150,-9"	WrapWidth="340"	WrapGrowth="Down"	StackGrowth="Right" />
 				</Grid>				
 				<Grid			ID="BonusGrid"													Offset="510,10"	Size="parent-515,40"				Style="SubContainer4"				Color="36,50,62,255" InnerPadding="2,2">
-					<Label																					Offset="5,0"																Style="ReportResourceText"	String="LOC_HUD_REPORTS_BONUSES" />
+					<!-- <Label																					Offset="5,0"																Style="ReportResourceText"	String="LOC_HUD_REPORTS_BONUSES" /> -->
+					<GridButton   ID="BonusCheckbox"  Anchor="L,C" Style="CheckBoxControl" String="LOC_HUD_REPORTS_BONUSES" Size="120,25" Offset="5,0" Hidden="0" />
 					<Stack	ID="BonusResources"				Anchor="L,C"	Offset="150,-9"	WrapWidth="340"	WrapGrowth="Down"	StackGrowth="Right" />
 				</Grid>
 				<Grid			ID="LuxuryGrid"													Offset="5,55"		Size="parent-10,40"					Style="SubContainer4"				Color="36,50,62,255" InnerPadding="2,2">
-					<Label																					Offset="5,0"																Style="ReportResourceText"	String="LOC_HUD_REPORTS_LUXURIES" />
+					<!-- <Label																					Offset="5,0"																Style="ReportResourceText"	String="LOC_HUD_REPORTS_LUXURIES" /> -->
+					<GridButton   ID="LuxuryCheckbox"  Anchor="L,C" Style="CheckBoxControl" String="LOC_HUD_REPORTS_LUXURIES" Size="120,25" Offset="5,0" Hidden="0" />
 					<Stack	ID="LuxuryResources"			Anchor="L,C"	Offset="150,-9"	WrapWidth="840"	WrapGrowth="Down"	StackGrowth="Right" />
 				</Grid>
 			</Image>


### PR DESCRIPTION
Adds checkboxes to Footer of Resources tab, to toggle resource types on and off the displayed list. Very useful when examining a specific type of resource.