### PR TITLE
Fix district checkbox error

### DIFF
--- a/Assets/UI/Panels/productionpanel.lua
+++ b/Assets/UI/Panels/productionpanel.lua
@@ -1106,19 +1106,13 @@ function PopulateList(data, listIM)
       local turnsStrTT:string = "";
       local turnsStr:string = "";
 
-      if(item.HasBeenBuilt and GameInfo.Districts[item.Type].OnePerCity == true and not item.Repair and not item.Contaminated and not item.TurnsLeft) then
+      if(item.HasBeenBuilt and GameInfo.Districts[item.Type].OnePerCity == true and not item.Repair and not item.Contaminated) then
         turnsStrTT = Locale.Lookup("LOC_HUD_CITY_DISTRICT_BUILT_TT");
         turnsStr = "[ICON_Checkmark]";
         districtListing.RecommendedIcon:SetHide(true);
       else
-        if(item.TurnsLeft) then
-          turnsStrTT = item.TurnsLeft .. Locale.Lookup("LOC_HUD_CITY_TURNS_TO_COMPLETE", item.TurnsLeft);
-          turnsStr = item.TurnsLeft .. "[ICON_Turn]";
-        else
-          turnsStrTT = Locale.Lookup("LOC_HUD_CITY_DISTRICT_BUILT_TT");
-          turnsStr = "[ICON_Checkmark]";
-          districtListing.RecommendedIcon:SetHide(true);
-        end
+        turnsStrTT = item.TurnsLeft .. Locale.Lookup("LOC_HUD_CITY_TURNS_TO_COMPLETE", item.TurnsLeft);
+        turnsStr = item.TurnsLeft .. "[ICON_Turn]";
       end
 
       if(item.Progress > 0) then


### PR DESCRIPTION
If a district has already been built, it displays the number of turns to build rather than a check mark.  This seems to fix the error.   This new code is almost the same as the original code.  I'm not sure what the mod was trying to do at this point, but it doesn't work.