### PR TITLE
Fix player color in custom pins

### DIFF
--- a/Assets/UI/mappinmanager.lua
+++ b/Assets/UI/mappinmanager.lua
@@ -241,6 +241,9 @@ function MapPinFlag.SetColor( self : MapPinFlag )
   -- Only set the color if it's a default map pin icon
   if (isDefaultMapPinIcon) then
     self.m_Instance.UnitIcon:SetColor( brighterIconColor );
+  else
+  -- Set color to white for all other pin icons.
+    self.m_Instance.UnitIcon:SetColor( 0xFFFFFFFF );
   end
   
   self.m_Instance.FlagBase:SetColor( primaryColor );


### PR DESCRIPTION
Fixes #154

I think the reason this appear is that the pins start out as a default map pin icon and is then changed when the icon is selected. At this point the color is already applied. This can be seen as the icons are as they should after a reload.

This fix is inspired by @Auda35 solution in the issue thread.