### PR TITLE
ToggleYieldIcons is now called after settings

### DIFF
--- a/Integrations/ML/UI/minimappanel.lua
+++ b/Integrations/ML/UI/minimappanel.lua
@@ -122,6 +122,13 @@ function CQUI_OnSettingsUpdate()
   --Cycles the minimap after resizing
   CQUI_UpdateMinimapSize();
 end
+
+function CQUI_ToggleYieldIcons()
+-- CQUI: Toggle yield icons if option is enabled
+  if(GameConfiguration.GetValue("CQUI_ToggleYieldsOnLoad")) then
+    ToggleYieldIcons();
+  end
+end
 -- ===========================================================================
 function GetContinentsCache()
   if m_ContinentsCache == nil then
@@ -2536,10 +2543,6 @@ function Initialize()
   LuaEvents.CQUI_Option_ToggleYields.Add( ToggleYieldIcons );
   LuaEvents.CQUI_SettingsUpdate.Add( CQUI_OnSettingsUpdate );
   LuaEvents.CQUI_SettingsInitialized.Add( CQUI_UpdateMinimapSize );
-
-  -- CQUI: Toggle yield icons if option is enabled
-  if(GameConfiguration.GetValue("CQUI_ToggleYieldsOnLoad")) then
-    ToggleYieldIcons();
-  end
+  LuaEvents.CQUI_SettingsInitialized.Add( CQUI_ToggleYieldIcons );
 end
 Initialize();


### PR DESCRIPTION
Fixes #303 

`minimappanel.lua` is loaded before `cqui_settingselement.lua` so the value for CQUI_ToggleYieldsOnLoad is not yet saved in the GameConfiguration table.

Spent way to much time on this trying to change the load order of the files, instead of just using the even handler. So if anyone knows how to actually change the load order I would like to know to ease my pain ;)