### PR TITLE
Fixes promotion symbol

### DIFF
--- a/Assets/UI/unitflagmanager.lua
+++ b/Assets/UI/unitflagmanager.lua
@@ -813,16 +813,16 @@ function UnitFlag.UpdatePromotions( self )
 			local unitExperience = pUnit:GetExperience();
 			if (unitExperience ~= nil) then
 				local promotionList :table = unitExperience:GetPromotions();
-				local UnitXP = unitExperience:GetExperiencePoints();
-				local UnitMaxXP = unitExperience:GetExperienceForNextLevel();
 				self.m_Instance.New_Promotion_Flag:SetHide(true);
-				if (UnitXP/UnitMaxXP) == 1 and isLocalPlayerUnit then
+				--ARISTOS: to test for available promotions! Previous test using XPs was faulty (Firaxis... :rolleyes:)
+				local bCanStart, tResults = UnitManager.CanStartCommand( pUnit, UnitCommandTypes.PROMOTE, true, true);
+				if bCanStart and isLocalPlayerUnit then
 					self.m_Instance.New_Promotion_Flag:SetHide(false);
 					self.m_Instance.UnitNumPromotions:SetText("[COLOR:StatBadCS]+[ENDCOLOR]");
 					self.m_Instance.Promotion_Flag:SetHide(false);
-				end
-
-				if (#promotionList > 0) then
+				--end
+				--ARISTOS: if already promoted, or no promotion available, show # of proms
+				elseif (#promotionList > 0) then
 					--[[
 					local tooltipString :string = "";
 					for i, promotion in ipairs(promotionList) do


### PR DESCRIPTION
Finally fixes the promotion symbol so that it is always displayed for local player units when there is a promotion action available. Previously, due to faulty Firaxis functions regarding XPs (not updating between promotion actions), the symbol would stay put even if the promotion action was taken. Also, previous code always overwrote the promotion symbol when there were already promotions for the unit. Now, promotion symbol is displayed even if there are already other promotions for the unit, and changes to the new number of promotions immediately after the promotion action.