### PR TITLE
Fixes #439.

### DIFF
--- a/Integrations/IDS/diplomacydealview.lua
+++ b/Integrations/IDS/diplomacydealview.lua
@@ -1974,7 +1974,7 @@ function PopulateAvailableCities(player : table, iconList : table)
 			local subType = entry.SubType;
 			local pCity = player:GetCities():FindID( type );
 			-- Handle occupied cities
-			if entry.ForTypeName ~= GetCityData(pCity).CityName and not pCity:IsOccupied() then --ARISTOS --pCity == nil then
+			if pCity == nil or (entry.ForTypeName ~= GetCityData(pCity).CityName and not pCity:IsOccupied()) then --ARISTOS
 				pCity = otherPlayer:GetCities():FindID( type );
 			end
 
@@ -2427,7 +2427,7 @@ function PopulateDealCities(player : table, iconList : table)
 				if (type == DealItemTypes.CITIES) then
 					local pCity = player:GetCities():FindID(valueType);
 					-- Handle occupied cities
-					if valueName ~= GetCityData(pCity).CityName and not pCity:IsOccupied() then --ARISTOS
+					if pCity == nil or (valueName ~= GetCityData(pCity).CityName and not pCity:IsOccupied()) then --ARISTOS
 						pCity = otherPlayer:GetCities():FindID(valueType);
 					end
 

--- a/Integrations/IDS/diplomacydealview.lua
+++ b/Integrations/IDS/diplomacydealview.lua
@@ -1454,7 +1454,7 @@ function OnClickAvailableCity(player, valueType, subType)
 
 		-- Already there?
 		local pDealItem = pDeal:FindItemByValueType(DealItemTypes.CITIES, subType, valueType, player:GetID());
-		if (pDealItem == nil) then
+		if (pDealItem == nil or pDealItem:GetValueTypeNameID() ~= GetCityData(player:GetCities():FindID(valueType)).CityName) then --ARISTOS
 			
 			-- No
 			pDealItem = pDeal:AddItemOfType(DealItemTypes.CITIES, player:GetID());
@@ -1841,17 +1841,18 @@ end
 -- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 function MakeCityToolTip(pCity : table)
 	local cityData = GetCityData(pCity);
-
+	local isLocalPlayerCity = pCity:GetOwner() == Game.GetLocalPlayer();
 	if (pCity ~= nil) then	
 		local szToolTip = Locale.ToUpper( Locale.Lookup(cityData.CityName)) .. "[NEWLINE]";
-		szToolTip = szToolTip .. Locale.Lookup("LOC_DEAL_CITY_POPULATION_TOOLTIP", pCity:GetPopulation()) .. "[NEWLINE]";		
-		szToolTip = szToolTip .. "[ICON_Food]" .. toPlusMinusString(cityData.FoodPerTurn) .. " ";
-		szToolTip = szToolTip .. "[ICON_Production]" .. toPlusMinusString(cityData.ProductionPerTurn) .. " ";
-		szToolTip = szToolTip .. "[ICON_Science]" .. toPlusMinusString(cityData.SciencePerTurn) .. " ";
-		szToolTip = szToolTip .. "[ICON_Culture]" .. toPlusMinusString(cityData.CulturePerTurn) .. " ";
-		szToolTip = szToolTip .. "[ICON_Faith]" .. toPlusMinusString(cityData.FaithPerTurn) .. " ";
-		szToolTip = szToolTip .. "[ICON_Gold]" .. toPlusMinusString(cityData.GoldPerTurn);
-
+		szToolTip = szToolTip .. Locale.Lookup("LOC_DEAL_CITY_POPULATION_TOOLTIP", pCity:GetPopulation()) .. "[NEWLINE]";
+		if isLocalPlayerCity then --ARISTOS: only show detailed info for cities owned or occupied by local player! CQUI non-cheat policy
+			szToolTip = szToolTip .. "[ICON_Food]" .. toPlusMinusString(cityData.FoodPerTurn) .. " ";
+			szToolTip = szToolTip .. "[ICON_Production]" .. toPlusMinusString(cityData.ProductionPerTurn) .. " ";
+			szToolTip = szToolTip .. "[ICON_Science]" .. toPlusMinusString(cityData.SciencePerTurn) .. " ";
+			szToolTip = szToolTip .. "[ICON_Culture]" .. toPlusMinusString(cityData.CulturePerTurn) .. " ";
+			szToolTip = szToolTip .. "[ICON_Faith]" .. toPlusMinusString(cityData.FaithPerTurn) .. " ";
+			szToolTip = szToolTip .. "[ICON_Gold]" .. toPlusMinusString(cityData.GoldPerTurn);
+		end
 		local districtNames = {};
 		local pCityDistricts = pCity:GetDistricts();
 		if (pCityDistricts ~= nil) then
@@ -1907,10 +1908,16 @@ function renderCity(pCity : table, player : table, targetContainer : table)
 	end
 	
 	button.PopulationLabel:SetText(tostring(cityData.Population));
-	button.FoodLabel:SetText("[ICON_FOOD]" .. toPlusMinusString(cityData.FoodPerTurn));
-	button.ProductionLabel:SetText("[ICON_PRODUCTION]" .. toPlusMinusString(cityData.ProductionPerTurn));
-	button.ScienceLabel:SetText("[ICON_SCIENCE]" .. toPlusMinusString(cityData.SciencePerTurn));
-
+	--ARISTOS: only show detailed info for cities owned or occupied by local player! CQUI non-cheat policy
+	if pCity:GetOwner() == Game.GetLocalPlayer() then
+		button.FoodLabel:SetText("[ICON_FOOD]" .. toPlusMinusString(cityData.FoodPerTurn));
+		button.ProductionLabel:SetText("[ICON_PRODUCTION]" .. toPlusMinusString(cityData.ProductionPerTurn));
+		button.ScienceLabel:SetText("[ICON_SCIENCE]" .. toPlusMinusString(cityData.SciencePerTurn));
+	else
+		button.FoodLabel:SetText("");
+		button.ProductionLabel:SetText("");
+		button.ScienceLabel:SetText("");
+	end
 	button.SelectButton:SetToolTipString( MakeCityToolTip(pCity) );
 
 	return button;
@@ -1967,7 +1974,7 @@ function PopulateAvailableCities(player : table, iconList : table)
 			local subType = entry.SubType;
 			local pCity = player:GetCities():FindID( type );
 			-- Handle occupied cities
-			if pCity == nil then
+			if entry.ForTypeName ~= GetCityData(pCity).CityName and not pCity:IsOccupied() then --ARISTOS --pCity == nil then
 				pCity = otherPlayer:GetCities():FindID( type );
 			end
 
@@ -2412,14 +2419,16 @@ function PopulateDealCities(player : table, iconList : table)
 		local pDealItem;
 		for pDealItem in pDeal:Items() do
 			local type = pDealItem:GetType();
+			local valueType = pDealItem:GetValueType(); --ARISTOS
+			local valueName = pDealItem:GetValueTypeNameID(); --ARISTOS
 			if (pDealItem:GetFromPlayerID() == player:GetID()) then
 				local dealItemID = pDealItem:GetID();
 				
 				if (type == DealItemTypes.CITIES) then
-					local pCity = player:GetCities():FindID(pDealItem:GetValueType());
+					local pCity = player:GetCities():FindID(valueType);
 					-- Handle occupied cities
-					if pCity == nil then
-						pCity = otherPlayer:GetCities():FindID(pDealItem:GetValueType());
+					if valueName ~= GetCityData(pCity).CityName and not pCity:IsOccupied() then --ARISTOS
+						pCity = otherPlayer:GetCities():FindID(valueType);
 					end
 
 					local icon = renderCity(pCity, player, iconList.ListStack);


### PR DESCRIPTION
Adds convoluted code to compensate for the huge vanilla bug that mismatches cities internal values in the deal window. For details see #439 conversations towards the end. Also contains code from another branch/PR that hides city details when not owned by local player.