### PR TITLE
Fixes lack of odds window when city range striking

### DIFF
--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -2133,9 +2133,11 @@ function OnCityRangeStrikeButtonClick( playerID, cityID )
   if (pCity == nil) then
     return;
   end;
-
-  UI.SetInterfaceMode(InterfaceModeTypes.CITY_RANGE_ATTACK);
-  UI.SelectCity( pCity );
+	--ARISTOS: fix for the range strike not showing odds window
+	UI.DeselectAll();
+	UI.SelectCity( pCity );
+	UI.SetInterfaceMode(InterfaceModeTypes.CITY_RANGE_ATTACK);
+  
 end
 
 -- ===========================================================================


### PR DESCRIPTION
This small fix makes the city range strike complete again, now it shows the odds window as in vanilla.