### PR TITLE
Expands Non-cheat policy measures. Resolves #406.

### DIFF
--- a/Integrations/IDS/diplomacydealview.lua
+++ b/Integrations/IDS/diplomacydealview.lua
@@ -1523,8 +1523,9 @@ function getImportedResources(playerID)
 		if ( otherID ~= playerID ) then
 			local pPlayerConfig :table = PlayerConfigurations[otherID];
 			local pDeals        :table = DealManager.GetPlayerDeals(playerID, otherID); -- ARISTOS: double filter Resources!
+			local isNotCheat	:boolean = (playerID == Game.GetLocalPlayer()) or (otherID == Game.GetLocalPlayer()); -- ARISTOS: non-cheat CQUI policy
 
-			if ( pDeals ~= nil ) then
+			if ( pDeals ~= nil and isNotCheat) then --ARISTOS: show only if local player is the importer or the exporter!!!
 				for i,pDeal in ipairs(pDeals) do
 					--if ( pDeal:IsValid() ) then --!! ARISTOS: Bug??? deal:IsValid() not always returns true even if the deal IS valid!!!
 						-- Add incoming resource deals
@@ -1576,8 +1577,9 @@ function getImportedResources(playerID)
 
 	-- Add resources provided by city states
 	for i, pMinorPlayer in ipairs(PlayerManager.GetAliveMinors()) do
-		local pMinorPlayerInfluence:table = pMinorPlayer:GetInfluence();		
-		if pMinorPlayerInfluence ~= nil then
+		local pMinorPlayerInfluence:table = pMinorPlayer:GetInfluence();
+		local hasMetLocalPlayer: boolean = Players[Game.GetLocalPlayer()]:GetDiplomacy():HasMet( pMinorPlayer:GetID() ); --ARISTOS: CQUI anti-cheat policy
+		if (pMinorPlayerInfluence ~= nil and hasMetLocalPlayer) then --ARISTOS: show only if local player has met the City State!!!
 			local suzerainID:number = pMinorPlayerInfluence:GetSuzerain();
 			if suzerainID == playerID then
 				for row in GameInfo.Resources() do

--- a/Integrations/IDS/diplomacydealview.xml
+++ b/Integrations/IDS/diplomacydealview.xml
@@ -92,18 +92,18 @@
                   SliceSize="1,1" 
                   SliceTextureSize="24,24" 
                   StateOffsetIncrement="0,24" Anchor="L,T" Color="255,255,255,200">
-            <Image ID="Icon" StretchMode="None" Size="50,502" Anchor="C,C"/>
+            <Image ID="Icon" StretchMode="None" Size="50,50" Anchor="C,C"/>
             <Label ID="AmountText" Style="FontNormalBold16" Anchor="R,B" Offset="3,0" FontStyle="Stroke" />
         </GridButton>
     </Instance>
 
     <!-- Untradeable Resources (Either imported via trade or city-state, or Qty == 0) -->
     <Instance Name="IconOnly_Resource_Untradeable">
-        <GridButton ID="SelectButton" Texture="Controls_ButtonControl_Gray" Size="42,42" SliceCorner="10,10" 
+        <GridButton ID="SelectButton" Texture="Controls_ButtonControl_Gray" Size="50,50" SliceCorner="10,10" 
                   SliceSize="1,1" 
                   SliceTextureSize="24,24" 
                   StateOffsetIncrement="0,24" Anchor="L,T">          
-            <Image ID="Icon" StretchMode="None" Size="32,32" Anchor="L,T" Color="255,255,255,170" Offset="2,2"/>
+            <Image ID="Icon" StretchMode="None" Size="50,50" Anchor="C,C" Color="255,255,255,170" />
             <Label ID="AmountText" Style="FontNormalBold16" Anchor="R,B" Offset="3,0" FontStyle="Stroke" />
         </GridButton>
     </Instance>


### PR DESCRIPTION
This small patch extends the non-cheat CQUI policy measures to:
+ Show resources imported only if the local player is the importer or the exporter (no more "Trade with other civ")
+ Show resources from suzerained City States only if the local player has met the specific CS.
+ Resolves #406 .
+ Extra perk: non-tradeable resources (Black) buttons now the same size as the others