### PR TITLE
Block End Turn if a city can attack

### DIFF
--- a/Assets/Text/cqui_text_settings.xml
+++ b/Assets/Text/cqui_text_settings.xml
@@ -108,6 +108,12 @@
     <Row Tag="LOC_CQUI_GENERAL_TOGGLEYIELDSONLOAD" Language="en_US">
       <Text>Toggles yields ON by default</Text>
     </Row>
+    <Row Tag="LOC_CQUI_GENERAL_BLOCKONCITYATTACK" Language="en_US">
+      <Text>Block end turn for city attack</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_GENERAL_BLOCKONCITYATTACK_TOOLTIP" Language="en_US">
+      <Text>Enable this if you want "End Turn" to be block if a city can attack.</Text>
+    </Row>
     <Row Tag="LOC_CQUI_GENERAL_TRANSPARENT" Language="en_US">
       <Text>Transparent</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings.xml
+++ b/Assets/Text/cqui_text_settings.xml
@@ -24,6 +24,12 @@
     <Row Tag="LOC_CQUI_CITYVIEW" Language="en_US">
       <Text>City View</Text>
     </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK" Language="en_US">
+      <Text>Block end turn for city attack</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP" Language="en_US">
+      <Text>Enable this if you want "End Turn" to be block if a city can attack.</Text>
+    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="en_US">
       <Text>Production item height</Text>
     </Row>
@@ -107,12 +113,6 @@
     </Row>
     <Row Tag="LOC_CQUI_GENERAL_TOGGLEYIELDSONLOAD" Language="en_US">
       <Text>Toggles yields ON by default</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_GENERAL_BLOCKONCITYATTACK" Language="en_US">
-      <Text>Block end turn for city attack</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_GENERAL_BLOCKONCITYATTACK_TOOLTIP" Language="en_US">
-      <Text>Enable this if you want "End Turn" to be block if a city can attack.</Text>
     </Row>
     <Row Tag="LOC_CQUI_GENERAL_TRANSPARENT" Language="en_US">
       <Text>Transparent</Text>

--- a/Assets/Text/cqui_text_settings_de.xml
+++ b/Assets/Text/cqui_text_settings_de.xml
@@ -108,6 +108,12 @@
     <Row Tag="LOC_CQUI_GENERAL_TOGGLEYIELDSONLOAD" Language="de_DE">
       <Text>Ansicht Erträge immer AN</Text>
     </Row>
+    <Row Tag="LOC_CQUI_GENERAL_BLOCKONCITYATTACK" Language="de_DE">
+      <Text>Stadtverteidigung verhindert Rundenende</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_GENERAL_BLOCKONCITYATTACK_TOOLTIP" Language="de_DE">
+      <Text>Der "Nächste Runde"-Button ist blockiert, solange eine Stadtverteidigung möglich ist.</Text>
+    </Row>
     <Row Tag="LOC_CQUI_GENERAL_TRANSPARENT" Language="de_DE">
       <Text>Transparent</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_de.xml
+++ b/Assets/Text/cqui_text_settings_de.xml
@@ -24,6 +24,12 @@
     <Row Tag="LOC_CQUI_CITYVIEW" Language="de_DE">
       <Text>Stadtansicht</Text>
     </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK" Language="de_DE">
+      <Text>Stadtverteidigung verhindert Rundenende</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP" Language="de_DE">
+      <Text>Der "Nächste Runde"-Button ist blockiert, solange eine Stadtverteidigung möglich ist.</Text>
+    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_ITEMHEIGHT" Language="de_DE">
       <Text>Zeilenhöhe i.d. Produktwahlliste</Text>
     </Row>
@@ -107,12 +113,6 @@
     </Row>
     <Row Tag="LOC_CQUI_GENERAL_TOGGLEYIELDSONLOAD" Language="de_DE">
       <Text>Ansicht Erträge immer AN</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_GENERAL_BLOCKONCITYATTACK" Language="de_DE">
-      <Text>Stadtverteidigung verhindert Rundenende</Text>
-    </Row>
-    <Row Tag="LOC_CQUI_GENERAL_BLOCKONCITYATTACK_TOOLTIP" Language="de_DE">
-      <Text>Der "Nächste Runde"-Button ist blockiert, solange eine Stadtverteidigung möglich ist.</Text>
     </Row>
     <Row Tag="LOC_CQUI_GENERAL_TRANSPARENT" Language="de_DE">
       <Text>Transparent</Text>

--- a/Assets/UI/actionpanel.lua
+++ b/Assets/UI/actionpanel.lua
@@ -117,6 +117,16 @@ local m_visibleBlockerTypes : table   = {};
 local m_isSlowTurnEnable  : boolean = false;                  -- Tutorial: when active slow to allow clicks when turn raises.
 
 -- ===========================================================================
+--  QUI
+-- ===========================================================================
+
+local cqui_blockOnCityAttack = true;
+function CQUI_OnSettingsUpdate()
+  cqui_blockOnCityAttack = GameConfiguration.GetValue("CQUI_BlockOnCityAttack");
+end
+LuaEvents.CQUI_SettingsUpdate.Add( CQUI_OnSettingsUpdate );
+
+-- ===========================================================================
 --  UI Event
 --  The View()
 -- ===========================================================================
@@ -388,7 +398,7 @@ end
 -- ===========================================================================
 function HaveCityRangeAttackStateEnabled()
   -- When is the "City Ranged Attack" end turn button enabled?
-  return  (UserConfiguration.IsAutoEndTurn()) and Game.IsAllowTacticalCommands(Game.GetLocalPlayer());
+  return  (UserConfiguration.IsAutoEndTurn() or cqui_blockOnCityAttack) and Game.IsAllowTacticalCommands(Game.GetLocalPlayer());
 end
 
 -- ===========================================================================
@@ -506,7 +516,11 @@ function DoEndTurn( optionalNewBlocker:number )
     elseif(CheckCityRangeAttackState()) then
       local attackCity = pPlayer:GetCities():GetFirstRangedAttackCity();
       if(attackCity ~= nil) then
-        UI.SelectCity(attackCity);
+        if cqui_blockOnCityAttack then
+          UI.LookAtPlot(attackCity:GetX(), attackCity:GetY());
+        else
+          UI.SelectCity(attackCity);
+        end
       else
         error( "Unable to find selectable attack city while in CheckCityRangeAttackState()" );
       end

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -36,6 +36,7 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
       ("CQUI_AutoapplyBuilderLens", 1), -- Automatically activates the builder lens when selecting a builder
       ("CQUI_AutoapplyScoutLens", 1), -- Automatically activates the scout lens when selecting a scout
       ("CQUI_AutoExpandUnitActions", 1), -- Automatically reveals the secondary unit actions normally hidden inside an expando
+      ("CQUI_BlockOnCityAttack", 1), -- Block turn from ending if you have a city that can attack
       ("CQUI_ProductionQueue", 1), -- A production queue appears next to the production panel, allowing multiple constructions to be queued at once
       ("CQUI_ShowCultureGrowth", 1), -- Shows cultural growth overlay in cityview
       ("CQUI_ShowLuxuries", 1), -- Luxury resources will show in the top-bar next to strategic resources
@@ -49,8 +50,7 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
       ("CQUI_SmartWorkIcon", 1), -- Applies a different size/transparency to citizen icons if they're currently being worked
       ("CQUI_TechPopupVisual", 0), -- Popups will be displayed when you discover a new tech or civic (this is the normal behavior for the unmoded game)
       ("CQUI_TechPopupAudio", 1), -- Play the voiceovers when you discover a new tech or civic (this is the normal behavior for the unmoded game)
-      ("CQUI_ToggleYieldsOnLoad", 1), -- Toggles yields immediately on load
-      ("CQUI_BlockOnCityAttack", 1); -- Block turn from ending if you have a city that can attack
+      ("CQUI_ToggleYieldsOnLoad", 1); -- Toggles yields immediately on load
 
 /*
     ┌────────────────────────────────────────────────────────────────────────────────────────────┐

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -49,7 +49,8 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
       ("CQUI_SmartWorkIcon", 1), -- Applies a different size/transparency to citizen icons if they're currently being worked
       ("CQUI_TechPopupVisual", 0), -- Popups will be displayed when you discover a new tech or civic (this is the normal behavior for the unmoded game)
       ("CQUI_TechPopupAudio", 1), -- Play the voiceovers when you discover a new tech or civic (this is the normal behavior for the unmoded game)
-      ("CQUI_ToggleYieldsOnLoad", 1); -- Toggles yields immediately on load
+      ("CQUI_ToggleYieldsOnLoad", 1), -- Toggles yields immediately on load
+      ("CQUI_BlockOnCityAttack", 1); -- Block turn from ending if you have a city that can attack
 
 /*
     ┌────────────────────────────────────────────────────────────────────────────────────────────┐

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -293,7 +293,7 @@ function Initialize()
   PopulateCheckBox(Controls.SmartbannerPopulationCheckbox, "CQUI_Smartbanner_Population", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_POPULATION_TOOLTIP"));
   PopulateCheckBox(Controls.SmartbannerCulturalCheckbox, "CQUI_Smartbanner_Cultural", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_CULTURAL_TOOLTIP"));
   PopulateCheckBox(Controls.ToggleYieldsOnLoadCheckbox, "CQUI_ToggleYieldsOnLoad");
-  PopulateCheckBox(Controls.BlockOnCityAttackCheckbox, "CQUI_BlockOnCityAttack", Locale.Lookup("LOC_CQUI_GENERAL_BLOCKONCITYATTACK_TOOLTIP"));
+  PopulateCheckBox(Controls.BlockOnCityAttackCheckbox, "CQUI_BlockOnCityAttack", Locale.Lookup("LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP"));
   PopulateCheckBox(Controls.TechVisualCheckbox, "CQUI_TechPopupVisual", Locale.Lookup("LOC_CQUI_POPUPS_TECHVISUAL_TOOLTIP"));
   PopulateCheckBox(Controls.TechAudioCheckbox, "CQUI_TechPopupAudio", Locale.Lookup("LOC_CQUI_POPUPS_TECHAUDIO_TOOLTIP"));
   PopulateCheckBox(Controls.TrimGossipCheckbox, "CQUI_TrimGossip", Locale.Lookup("LOC_CQUI_GOSSIP_TRIMMESSAGE_TOOLTIP"));

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -293,6 +293,7 @@ function Initialize()
   PopulateCheckBox(Controls.SmartbannerPopulationCheckbox, "CQUI_Smartbanner_Population", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_POPULATION_TOOLTIP"));
   PopulateCheckBox(Controls.SmartbannerCulturalCheckbox, "CQUI_Smartbanner_Cultural", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_CULTURAL_TOOLTIP"));
   PopulateCheckBox(Controls.ToggleYieldsOnLoadCheckbox, "CQUI_ToggleYieldsOnLoad");
+  PopulateCheckBox(Controls.BlockOnCityAttackCheckbox, "CQUI_BlockOnCityAttack", Locale.Lookup("LOC_CQUI_GENERAL_BLOCKONCITYATTACK_TOOLTIP"));
   PopulateCheckBox(Controls.TechVisualCheckbox, "CQUI_TechPopupVisual", Locale.Lookup("LOC_CQUI_POPUPS_TECHVISUAL_TOOLTIP"));
   PopulateCheckBox(Controls.TechAudioCheckbox, "CQUI_TechPopupAudio", Locale.Lookup("LOC_CQUI_POPUPS_TECHAUDIO_TOOLTIP"));
   PopulateCheckBox(Controls.TrimGossipCheckbox, "CQUI_TrimGossip", Locale.Lookup("LOC_CQUI_GOSSIP_TRIMMESSAGE_TOOLTIP"));

--- a/Assets/cqui_settingselement.xml
+++ b/Assets/cqui_settingselement.xml
@@ -78,11 +78,11 @@
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <GridButton ID="ShowYieldsOnCityHoverCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWYIELDSONCITYHOVER" />
           </Stack>
-          <Stack Anchor="C,C" StackGrowth="Left">
-            <Label Anchor="C,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_SMARTBANNER_HEADER" Offset="0,10"/>
-          </Stack>
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <GridButton ID="BlockOnCityAttackCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK" />
+          </Stack>
+          <Stack Anchor="C,C" StackGrowth="Left">
+            <Label Anchor="C,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_SMARTBANNER_HEADER" Offset="0,10"/>
           </Stack>
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <GridButton ID="SmartbannerCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SMARTBANNER" />

--- a/Assets/cqui_settingselement.xml
+++ b/Assets/cqui_settingselement.xml
@@ -38,9 +38,6 @@
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <GridButton ID="ToggleYieldsOnLoadCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_GENERAL_TOGGLEYIELDSONLOAD" />
           </Stack>
-          <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
-            <GridButton ID="BlockOnCityAttackCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_GENERAL_BLOCKONCITYATTACK" />
-          </Stack>
           <Grid Size="0,35" Anchor="R,T" AutoSize="H" Color="0,0,0,0">
             <Stack Anchor="C,T" StackGrowth="Left" Padding="3">
               <Label String="777" Style="ShellOptionText" Anchor="L,C" ID="MinimapSizeText" />
@@ -83,6 +80,9 @@
           </Stack>
           <Stack Anchor="C,C" StackGrowth="Left">
             <Label Anchor="C,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_SMARTBANNER_HEADER" Offset="0,10"/>
+          </Stack>
+          <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+            <GridButton ID="BlockOnCityAttackCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_GENERAL_BLOCKONCITYATTACK" />
           </Stack>
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <GridButton ID="SmartbannerCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SMARTBANNER" />

--- a/Assets/cqui_settingselement.xml
+++ b/Assets/cqui_settingselement.xml
@@ -82,7 +82,7 @@
             <Label Anchor="C,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_SMARTBANNER_HEADER" Offset="0,10"/>
           </Stack>
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
-            <GridButton ID="BlockOnCityAttackCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_GENERAL_BLOCKONCITYATTACK" />
+            <GridButton ID="BlockOnCityAttackCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK" />
           </Stack>
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <GridButton ID="SmartbannerCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SMARTBANNER" />

--- a/Assets/cqui_settingselement.xml
+++ b/Assets/cqui_settingselement.xml
@@ -38,6 +38,9 @@
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <GridButton ID="ToggleYieldsOnLoadCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_GENERAL_TOGGLEYIELDSONLOAD" />
           </Stack>
+          <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+            <GridButton ID="BlockOnCityAttackCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_GENERAL_BLOCKONCITYATTACK" />
+          </Stack>
           <Grid Size="0,35" Anchor="R,T" AutoSize="H" Color="0,0,0,0">
             <Stack Anchor="C,T" StackGrowth="Left" Padding="3">
               <Label String="777" Style="ShellOptionText" Anchor="L,C" ID="MinimapSizeText" />


### PR DESCRIPTION
* On by default
* Option added to disable it
* Shows city instead of selecting it since you can't attack when city is
selected

Adds two new LOCs
* LOC_CQUI_GENERAL_BLOCKONCITYATTACK
* LOC_CQUI_GENERAL_BLOCKONCITYATTACK_TOOLTIP

If someone thinks of a better wording for this please change it!

Firaxis choose to only enable End Turn blocking for city attack if you use "Auto End Turn". But I want it without having to use that feature :P