### PR TITLE
Don't Reload CityBanner on CQUI_SettingsInitialized

### DIFF
--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -168,7 +168,7 @@ local CQUI_SmartWorkIconSize: number = 64;
 local CQUI_SmartWorkIconAlpha = .45;
 
 local g_smartbanner = true;
-function CQUI_OnSettingsUpdate()
+function CQUI_OnSettingsUpdate( settingsInitialized:boolean )
   CQUI_ShowYieldsOnCityHover = GameConfiguration.GetValue("CQUI_ShowYieldsOnCityHover");
   g_smartbanner = GameConfiguration.GetValue("CQUI_Smartbanner");
   g_smartbanner_unmanaged_citizen = GameConfiguration.GetValue("CQUI_Smartbanner_UnlockedCitizen");
@@ -181,7 +181,10 @@ function CQUI_OnSettingsUpdate()
   CQUI_SmartWorkIcon = GameConfiguration.GetValue("CQUI_SmartWorkIcon");
   CQUI_SmartWorkIconSize = GameConfiguration.GetValue("CQUI_SmartWorkIconSize");
   CQUI_SmartWorkIconAlpha = GameConfiguration.GetValue("CQUI_SmartWorkIconAlpha") / 100;
-  Reload();
+
+  if not settingsInitialized then
+    Reload();
+  end
 end
 LuaEvents.CQUI_SettingsUpdate.Add( CQUI_OnSettingsUpdate );
 
@@ -2137,7 +2140,7 @@ function OnCityRangeStrikeButtonClick( playerID, cityID )
 	UI.DeselectAll();
 	UI.SelectCity( pCity );
 	UI.SetInterfaceMode(InterfaceModeTypes.CITY_RANGE_ATTACK);
-  
+
 end
 
 -- ===========================================================================

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -3220,6 +3220,7 @@ function Initialize()
 
   LuaEvents.GameDebug_Return.Add(OnGameDebugReturn);
 
+  LuaEvents.CQUI_SettingsInitialized.Add( CQUI_OnSettingsInitialized );
   Events.CitySelectionChanged.Add( CQUI_OnBannerMouseExit );
 end
 Initialize();

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -166,9 +166,9 @@ local CQUI_WorkIconAlpha = .60;
 local CQUI_SmartWorkIcon: boolean = true;
 local CQUI_SmartWorkIconSize: number = 64;
 local CQUI_SmartWorkIconAlpha = .45;
-
 local g_smartbanner = true;
-function CQUI_OnSettingsUpdate( settingsInitialized:boolean )
+
+function CQUI_OnSettingsInitialized()
   CQUI_ShowYieldsOnCityHover = GameConfiguration.GetValue("CQUI_ShowYieldsOnCityHover");
   g_smartbanner = GameConfiguration.GetValue("CQUI_Smartbanner");
   g_smartbanner_unmanaged_citizen = GameConfiguration.GetValue("CQUI_Smartbanner_UnlockedCitizen");
@@ -181,10 +181,11 @@ function CQUI_OnSettingsUpdate( settingsInitialized:boolean )
   CQUI_SmartWorkIcon = GameConfiguration.GetValue("CQUI_SmartWorkIcon");
   CQUI_SmartWorkIconSize = GameConfiguration.GetValue("CQUI_SmartWorkIconSize");
   CQUI_SmartWorkIconAlpha = GameConfiguration.GetValue("CQUI_SmartWorkIconAlpha") / 100;
+end
 
-  if not settingsInitialized then
-    Reload();
-  end
+function CQUI_OnSettingsUpdate()
+  CQUI_OnSettingsInitialized();
+  Reload();
 end
 LuaEvents.CQUI_SettingsUpdate.Add( CQUI_OnSettingsUpdate );
 
@@ -3219,7 +3220,6 @@ function Initialize()
 
   LuaEvents.GameDebug_Return.Add(OnGameDebugReturn);
 
-  LuaEvents.CQUI_SettingsInitialized.Add(CQUI_OnSettingsUpdate);
   Events.CitySelectionChanged.Add( CQUI_OnBannerMouseExit );
 end
 Initialize();

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -323,7 +323,7 @@ function Initialize()
   LuaEvents.CQUI_SettingsUpdate.Add(ToggleSmartbannerCheckboxes);
   LuaEvents.CQUI_SettingsUpdate.Add(ToggleSmartWorkIconSettings);
 
-  LuaEvents.CQUI_SettingsInitialized(); --Tell other elements that the settings have been initialized and it's safe to try accessing settings now
+  LuaEvents.CQUI_SettingsInitialized(true); --Tell other elements that the settings have been initialized and it's safe to try accessing settings now
 end
 
 function ToggleSmartbannerCheckboxes()

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -323,7 +323,7 @@ function Initialize()
   LuaEvents.CQUI_SettingsUpdate.Add(ToggleSmartbannerCheckboxes);
   LuaEvents.CQUI_SettingsUpdate.Add(ToggleSmartWorkIconSettings);
 
-  LuaEvents.CQUI_SettingsInitialized(true); --Tell other elements that the settings have been initialized and it's safe to try accessing settings now
+  LuaEvents.CQUI_SettingsInitialized(); --Tell other elements that the settings have been initialized and it's safe to try accessing settings now
 end
 
 function ToggleSmartbannerCheckboxes()


### PR DESCRIPTION
Not sure exactly why but if we don't run Reload on
CQUI_SettingsInitialized for the CityBanner then it seems to work, so I
guess it is run to soon for the objects to be in place or something.

Would be good to test this a bit to make sure that it does not break
anything else instead.

Fixes #201 