### PR TITLE
Issue506

### DIFF
--- a/Assets/UI/PartialScreens/citystates.lua
+++ b/Assets/UI/PartialScreens/citystates.lua
@@ -853,6 +853,7 @@ function AddCityStateRow( kCityState:table )
 end
 
 function CQUI_TruncateSuzerainName( name:string )
+  if(name:len() >= 12) then
     return string.sub(name, 0, 10) .. "...";
   else
     return name;

--- a/Assets/UI/PartialScreens/citystates.lua
+++ b/Assets/UI/PartialScreens/citystates.lua
@@ -796,7 +796,7 @@ function AddCityStateRow( kCityState:table )
   kInst.BonusTextSuzerain:SetText( kCityState.SuzerainTokensNeeded );
   kInst.SuzerainLabel:SetColor( kCityState.isBonusSuzerain and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
   kInst.Suzerain:SetColor( kCityState.isBonusSuzerain and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
-  kInst.Suzerain:SetText( kCityState.SuzerainName );
+  kInst.Suzerain:SetText( CQUI_TruncateSuzerainName(kCityState.SuzerainName) );
 
   -- Begin CQUI Changes Marker
   local localPlayerID = Game.GetLocalPlayer();
@@ -836,7 +836,7 @@ function AddCityStateRow( kCityState:table )
   -- CQUI Note: SecondHighestLabel needs to be localized, but is hard coded for now
   kInst.SecondHighestLabel:SetText( "2nd" );
   kInst.SecondHighestName:SetColor( secondHighestIsPlayer and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
-  kInst.SecondHighestName:SetText( secondHighestName );
+  kInst.SecondHighestName:SetText( CQUI_TruncateSuzerainName(secondHighestName) );
   kInst.SecondHighestEnvoys:SetColor( secondHighestIsPlayer and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
   kInst.SecondHighestEnvoys:SetText( secondHighestEnvoys );
   -- End CQUI Changes Marker
@@ -850,6 +850,13 @@ function AddCityStateRow( kCityState:table )
   kInst.Button:RegisterCallback( Mouse.eLClick, function() OpenSingleViewCityState( kCityState.iPlayer ) end );
 
   return kInst;
+end
+
+function CQUI_TruncateSuzerainName( name:string )
+    return string.sub(name, 0, 10) .. "...";
+  else
+    return name;
+  end
 end
 
 -- ===========================================================================

--- a/Assets/UI/PartialScreens/citystates.xml
+++ b/Assets/UI/PartialScreens/citystates.xml
@@ -188,16 +188,16 @@
         <Image    ID="BonusIcon6"            Anchor="C,B"                  Size="26,26"          Texture="EnvoyBonuses26"          TextureOffset="104,0"  />
       </Image>
       <!-- CQUI Note: The size of the container below was changed from 108 to 120 in order to fix a spacing issue. -->
-      <Container                            Anchor="L,C"  Offset="346,0"  Size="120,42">
-        <Grid      ID="BonusImageSuzerainOff"                              Size="parent,parent"  Texture="CityState_BonusSlotBigOff" SliceCorner="31,21" SliceTextureSize="34,42"  />
-        <Grid      ID="BonusImageSuzerainOn"                                Size="parent,parent"  Texture="CityState_BonusSlotBigOn"  SliceCorner="31,21" SliceTextureSize="34,42"    />
-        <Label    ID="BonusTextSuzerain"    Anchor="R,T"  Offset="4,2"                          Style="FontNormal12"                String="4" />
-        <Image    ID="BonusIconSuzerain"    Anchor="L,T"  Offset="2,0"    Size="26,26"          Texture="EnvoyBonuses26"            TextureOffset="156,0"  />
-        <Label    ID="SecondHighestLabel"   Anchor="L,B"  Offset="3,0"                          Style="FontNormal12" />
-        <Label    ID="SuzerainLabel"        Anchor="L,T"  Offset="32,14"                        Style="FontNormal12"                String="LOC_CITY_STATES_SUZERAIN" />
-        <Label    ID="Suzerain"              Anchor="L,T"  Offset="32,2"                          Style="FontNormal12"                String="LOC_CITY_STATES_NONE" />
-        <Label    ID="SecondHighestName"    Anchor="L,B"  Offset="32,0"                         Style="FontNormal12" />
-        <Label    ID="SecondHighestEnvoys"  Anchor="R,B"  Offset="4,0"                          Style="FontNormal12" />
+      <Container                             Anchor="L,C"  Offset="346,0"  Size="120,42">
+        <Grid     ID="BonusImageSuzerainOff"                               Size="parent,parent"  Texture="CityState_BonusSlotBigOff" SliceCorner="31,21" SliceTextureSize="34,42"  />
+        <Grid     ID="BonusImageSuzerainOn"                                Size="parent,parent"  Texture="CityState_BonusSlotBigOn"  SliceCorner="31,21" SliceTextureSize="34,42"    />
+        <Label    ID="BonusTextSuzerain"     Anchor="R,B"  Offset="4,2"                          Style="FontNormal12"                String="4" />
+        <Image    ID="BonusIconSuzerain"     Anchor="L,B"  Offset="2,0"    Size="26,26"          Texture="EnvoyBonuses26"            TextureOffset="156,0"  />
+        <Label    ID="SecondHighestLabel"    Anchor="L,T"  Offset="3,0"                          Style="FontNormal12" />
+        <Label    ID="SuzerainLabel"         Anchor="L,B"  Offset="32,14"                        Style="FontNormal12"                String="LOC_CITY_STATES_SUZERAIN" />
+        <Label    ID="Suzerain"              Anchor="L,B"  Offset="32,2"                          Style="FontNormal12"                String="LOC_CITY_STATES_NONE" />
+        <Label    ID="SecondHighestName"     Anchor="L,T"  Offset="32,0"                         Style="FontNormal12" />
+        <Label    ID="SecondHighestEnvoys"   Anchor="R,T"  Offset="4,0"                          Style="FontNormal12" />
       </Container>
 
       <Button      ID="LookAtButton"          Anchor="R,C"  Offset="3,-7"    Size="23,31"          Texture="Controls_ShowMe"          StateOffsetIncrement="0,0"  ToolTip="LOC_CITY_STATES_LOOK_AT" />


### PR DESCRIPTION
Fixes #506 

Truncates leader names when longer than 12 chars and adds ... to the end

Swaped places of suzerain and 2nd since the background circel was not lining up with the suzerain star and I was not able to reposition the background circle.