### PR TITLE
Added turns left to icons in launchbar

### DIFF
--- a/Assets/UI/launchbar.lua
+++ b/Assets/UI/launchbar.lua
@@ -477,8 +477,10 @@ function OnTurnBegin()
 		local cost				:number	= playerTechs:GetResearchCost(currentTechID);
 
 		Controls.ScienceMeter:SetPercent(progress/cost);
+    Controls.ScienceTurnsLeft:SetText(playerTechs:GetTurnsLeft());
 	else
 		Controls.ScienceMeter:SetPercent(0);
+    Controls.ScienceTurnsLeft:SetText("");
 	end
 
 	local techInfo:table = GameInfo.Technologies[currentTechID];
@@ -498,8 +500,10 @@ function OnTurnBegin()
 		local civicCost				:number	= playerCivics:GetCultureCost(currentCivicID);
 
 		Controls.CultureMeter:SetPercent(civicProgress/civicCost);
+    Controls.CultureTurnsLeft:SetText(playerCivics:GetTurnsLeft());
 	else
 		Controls.CultureMeter:SetPercent(0);
+    Controls.CultureTurnsLeft:SetText("");
 	end
 
 	local CivicInfo:table = GameInfo.Civics[currentCivicID];

--- a/Assets/UI/launchbar.xml
+++ b/Assets/UI/launchbar.xml
@@ -93,18 +93,20 @@
 
   <Container ID="ScienceHookWithMeter"	Anchor="L,T" Offset="1,25" Size="57,57" Hidden="1">
 	  <Button	 ID="ScienceMeterButton"	Anchor="C,C"	 Offset="0,1"		 Size="51,51"   Texture="LaunchBar_Hook_ScienceButton" Style="ButtonNormalText"     TextureOffset="4,9"   StateOffsetIncrement="0,60" ToolTip="LOC_HUD_TECHTREE_TOOLTIP" Hidden="0">
-      <Image															Anchor="C,C" Size="57,57"	Texture="LaunchBar_Hook_CultureMeter_Backing.dds" Hidden="0" Offset="-1,-5">
-        <Meter	ID="ScienceMeter"					Anchor="C,C"								Size="57,57"	Texture="LaunchBar_Hook_ScienceMeter_Fill.dds" Percent="0" Speed="1.0" Follow="1" Offset="0,1"/>
-        <Image		ID="ResearchIcon"				Anchor="C,C"	Size="38,38"	Texture="Tech38" />
+      <Image													Anchor="C,C" Size="57,57"	Texture="LaunchBar_Hook_CultureMeter_Backing.dds" Hidden="0" Offset="-1,-5">
+        <Meter	ID="ScienceMeter"			Anchor="C,C"								Size="57,57"	Texture="LaunchBar_Hook_ScienceMeter_Fill.dds" Percent="0" Speed="1.0" Follow="1" Offset="0,1"/>
+        <Image	ID="ResearchIcon"			Anchor="C,C"	Size="38,38"	Texture="Tech38" Alpha="0.7"/>
+        <Label  ID="ScienceTurnsLeft" Anchor="C,C" String="" FontStyle="stroke" Color0="160,188,220,255"	Color1="0,0,0,200" Color2="255,255,255,255" Style="FontNormal20"/>
       </Image>
 	  </Button>
   </Container>
 
   <Container ID="CultureHookWithMeter"	Anchor="L,T" Offset="54,25" Size="57,57" Hidden="1">
     <Button	  ID="CultureMeterButton"	Anchor="C,C"	 Offset="0,1"	        Size="51,51"  Texture="LaunchBar_Hook_CultureButton" Style="ButtonNormalText"     TextureOffset="4,9"   StateOffsetIncrement="0,60" ToolTip="LOC_HUD_CIVICSTREE_TOOLTIP" Hidden="0">
-      <Image											  Anchor="C,C"  Size="57,57"	Texture="LaunchBar_Hook_CultureMeter_Backing.dds" Hidden="0" Offset="-1,-5">
-        <Meter	ID="CultureMeter"	  Anchor="C,C"	Size="57,57"	Texture="LaunchBar_Hook_CultureMeter_Fill.dds" Percent="0" Speed="1.0" Follow="1"/>
-        <Image  ID="CultureIcon"		Anchor="C,C" 	Size="38,38"	Texture="Civics38" />
+      <Image											    Anchor="C,C"  Size="57,57"	Texture="LaunchBar_Hook_CultureMeter_Backing.dds" Hidden="0" Offset="-1,-5">
+        <Meter	ID="CultureMeter"	    Anchor="C,C"	Size="57,57"	Texture="LaunchBar_Hook_CultureMeter_Fill.dds" Percent="0" Speed="1.0" Follow="1"/>
+        <Image  ID="CultureIcon"		  Anchor="C,C" 	Size="38,38"	Texture="Civics38" Alpha="0.8" />
+        <Label  ID="CultureTurnsLeft" Anchor="C,C" String="" FontStyle="stroke" Color0="160,188,220,255"	Color1="0,0,0,200" Color2="255,255,255,255" Style="FontNormal20"/>
       </Image>
     </Button>
   </Container>


### PR DESCRIPTION
Resolves #516 

Tried to make the numbers as visible as possible while still showing the icons underneath. Have not tried with all icons so we might need to tweak it more in the future.