### PR TITLE
Show leader icon in City state banner when Suzerain

### DIFF
--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -1573,6 +1573,33 @@ function CityBanner.UpdateName( self : CityBanner )
         end
       end
 
+      -- CQUI: Show leader icon for the suzerain
+      local pPlayerConfig :table = PlayerConfigurations[owner];
+      local isMinorCiv :boolean = pPlayerConfig:GetCivilizationLevelTypeID() ~= CivilizationLevelTypes.CIVILIZATION_LEVEL_FULL_CIV;
+      if isMinorCiv then
+        local pPlayerInfluence :table  = pPlayer:GetInfluence();
+        if pPlayerInfluence ~= nil then
+          local suzerainID :number = pPlayerInfluence:GetSuzerain();
+          if suzerainID ~= -1 then
+            local leader:string = PlayerConfigurations[suzerainID]:GetLeaderTypeName();
+            if GameInfo.CivilizationLeaders[leader] == nil then
+              UI.DataError("Banners found a leader \""..leader.."\" which is not/no longer in the game; icon may be whack.");
+            else
+              if pPlayer:GetDiplomacy():HasMet(suzerainID) then
+                self.m_Instance.CQUI_CivSuzerainIcon:SetIcon("ICON_" .. leader);
+              else
+                self.m_Instance.CQUI_CivSuzerainIcon:SetIcon("ICON_" .. "LEADER_DEFAULT");
+              end
+              self:Resize();
+              self.m_Instance.CQUI_CivSuzerain:SetOffsetX(self.m_Instance.ContentStack:GetSizeX()/2 - 5);
+              self.m_Instance.CQUI_CivSuzerain:SetHide(false);
+            end
+          else
+            self.m_Instance.CQUI_CivSuzerain:SetHide(true);
+          end
+        end
+      end
+
       self.m_Instance.CityQuestIcon:SetToolTipString(questTooltip);
       self.m_Instance.CityQuestIcon:SetText(statusString);
       self.m_Instance.CityName:SetText( cityName );

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -3157,7 +3157,11 @@ function CQUI_UpdateSuzerainIcon( pPlayer:table, bannerInstance:CityBanner )
       local suzerainTooltip = Locale.Lookup("LOC_CITY_STATES_SUZERAIN_LIST") .. " ";
       if pPlayer:GetDiplomacy():HasMet(suzerainID) then
         bannerInstance.m_Instance.CQUI_CivSuzerainIcon:SetIcon("ICON_" .. leader);
-        bannerInstance.m_Instance.CQUI_CivSuzerainIcon:SetToolTipString(suzerainTooltip .. Locale.Lookup(pPlayerConfig:GetPlayerName()));
+        if(suzerainID == Game.GetLocalPlayer()) then
+          bannerInstance.m_Instance.CQUI_CivSuzerainIcon:SetToolTipString(suzerainTooltip .. Locale.Lookup("LOC_CITY_STATES_YOU"));
+        else
+          bannerInstance.m_Instance.CQUI_CivSuzerainIcon:SetToolTipString(suzerainTooltip .. Locale.Lookup(pPlayerConfig:GetPlayerName()));
+        end
       else
         bannerInstance.m_Instance.CQUI_CivSuzerainIcon:SetIcon("ICON_LEADER_DEFAULT");
         bannerInstance.m_Instance.CQUI_CivSuzerainIcon:SetToolTipString(suzerainTooltip .. Locale.Lookup("LOC_DIPLOPANEL_UNMET_PLAYER"));

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -3149,14 +3149,18 @@ function CQUI_UpdateSuzerainIcon( pPlayer:table, bannerInstance:CityBanner )
   local pPlayerInfluence :table  = pPlayer:GetInfluence();
   local suzerainID       :number = pPlayerInfluence:GetSuzerain();
   if suzerainID ~= -1 then
-    local leader:string = PlayerConfigurations[suzerainID]:GetLeaderTypeName();
+    local pPlayerConfig :table  = PlayerConfigurations[suzerainID];
+    local leader        :string = pPlayerConfig:GetLeaderTypeName();
     if GameInfo.CivilizationLeaders[leader] == nil then
       UI.DataError("Banners found a leader \""..leader.."\" which is not/no longer in the game; icon may be whack.");
     else
+      local suzerainTooltip = Locale.Lookup("LOC_CITY_STATES_SUZERAIN_LIST") .. " ";
       if pPlayer:GetDiplomacy():HasMet(suzerainID) then
         bannerInstance.m_Instance.CQUI_CivSuzerainIcon:SetIcon("ICON_" .. leader);
+        bannerInstance.m_Instance.CQUI_CivSuzerainIcon:SetToolTipString(suzerainTooltip .. Locale.Lookup(pPlayerConfig:GetPlayerName()));
       else
         bannerInstance.m_Instance.CQUI_CivSuzerainIcon:SetIcon("ICON_LEADER_DEFAULT");
+        bannerInstance.m_Instance.CQUI_CivSuzerainIcon:SetToolTipString(suzerainTooltip .. Locale.Lookup("LOC_DIPLOPANEL_UNMET_PLAYER"));
       end
       bannerInstance:Resize();
       bannerInstance.m_Instance.CQUI_CivSuzerain:SetOffsetX(bannerInstance.m_Instance.ContentStack:GetSizeX()/2 - 5);

--- a/Assets/UI/WorldView/citybannermanager.xml
+++ b/Assets/UI/WorldView/citybannermanager.xml
@@ -195,9 +195,9 @@
         </Button>
 
         <!-- CQUI: Show Suzerain in CS banner -->
-        <Container ID="CQUI_CivSuzerain" Anchor="C,C" Offset="0,-10" Size="34,34" Hidden="1" >
-          <Image Size="26,26"  Offset="1,0" Anchor="C,C" Texture="Banner_ProductionCircle">
-            <Image ID="CQUI_CivSuzerainIcon" Size="25,25" Texture="Leaders45" Anchor="L,T" Offset="1,0" />
+        <Container ID="CQUI_CivSuzerain" Anchor="C,C" Offset="-8,-10" Size="34,34" Hidden="1" >
+          <Image Size="31,31"  Offset="1,0" Anchor="C,C" Texture="Banner_ProductionCircle">
+            <Image ID="CQUI_CivSuzerainIcon" Size="30,30" Texture="Leaders45" Anchor="L,T" Offset="1,0" />
           </Image>
         </Container>
 

--- a/Assets/UI/WorldView/citybannermanager.xml
+++ b/Assets/UI/WorldView/citybannermanager.xml
@@ -24,8 +24,8 @@
       <Button       ID="CitizenButton"  Anchor="C,T"  Offset="0,-50"  Size="64,64" Alpha=".50"      Texture="CityPanel_ManageCitizenButton.dds" Hidden="1"  NoStateChange="1" />
       <Image      ID="LockedIcon"     Anchor="R,B"  Offset="-35,30" Size="32,32"    Texture="Padlock" Hidden="1"/>
     </WorldAnchor>
-  </Instance>  
-  
+  </Instance>
+
   <!-- Local Team Banner -->
   <Instance               Name="TeamCityBanner">
     <WorldAnchor          ID="Anchor">
@@ -162,7 +162,7 @@
     </WorldAnchor>
   </Instance>
 
-  
+
   <!-- Other Team Banners' -->
   <Instance               Name="OtherCityBanner">
     <WorldAnchor          ID="Anchor" >
@@ -194,6 +194,13 @@
           </AlphaAnim>
         </Button>
 
+        <!-- CQUI: Show Suzerain in CS banner -->
+        <Container ID="CQUI_CivSuzerain" Anchor="C,C" Offset="0,-10" Size="34,34" Hidden="1" >
+          <Image Size="26,26"  Offset="1,0" Anchor="C,C" Texture="Banner_ProductionCircle">
+            <Image ID="CQUI_CivSuzerainIcon" Size="25,25" Texture="Leaders45" Anchor="L,T" Offset="1,0" />
+          </Image>
+        </Container>
+
         <!-- Banner Contents  -->
         <Stack              ID="ContentStack" StackGrowth="Right" Padding="5" Anchor="C,T">
 
@@ -202,7 +209,7 @@
             <Label          ID="CityPopTurnsLeft"       AnchorSide="O,I" Offset="3,-2" Style="StrongSmall2" KerningAdjustment="-1" Hidden="1"/>
             <Label          ID="CityCultureTurnsLeft"       AnchorSide="O,I" Offset="3,-2" Style="StrongSmall2" KerningAdjustment="-1" Hidden="1"/>
           </Container>
-            
+
           <Container        ID="CityNameContainer"            Anchor ="L,C" Size="50,34">
             <Stack          ID="CityNameStack"                StackGrowth="Right" Padding="2" Anchor="C,C" >
               <Label        ID="TradingPostIcon"              Anchor="R,C" Offset="0,2" String="[ICON_TradingPost]" Hidden="1">
@@ -230,11 +237,10 @@
             </AlphaAnim>
             <Label          ID="CityProdTurnsLeft" Anchor="R,T" AnchorSide="O,I" Offset="3,-2" Style="StrongSmall" KerningAdjustment="-1"/>
           </Container>
-                      
           <Image            ID="CivIcon" Texture="CivSymbols30" Size="30,30" Anchor="L,C" />
           <Container        ID="CivIconEndPadding" Size="1,1" />
         </Stack>
-          
+
         <Grid               ID="CityStateQuest" Texture="CityStateQuest28" SliceTextureSize="28,23" SliceCorner="14,6" Size="28,30" Hidden="1" Offset="-5,-22" />
 
         <Image              ID="CityAttackContainer" Texture="CityBannerRangeAttackRim" Size="36,45" Anchor="C,B" AnchorSide="I,O" Offset="0,-6">
@@ -274,7 +280,6 @@
           <Stack        ID="FollowerStack"    Anchor="L,C" Offset="120,0" StackGrowth="Down" />
           <Container    ID="ReligionChanges"  Anchor="C,C" />
         </Container>
-      
       </Container>
     </WorldAnchor>
   </Instance>
@@ -290,7 +295,7 @@
           <Label ID="AerodromeMaxUnitCount" Style="FontNormal14" String="4"/>
         </Stack>
       </Grid>
-      
+
       <PullDown ID="UnitListPopup" ConsumeMouse="0" Offset="0,0" Anchor="C,C" Size="200,20" AutoSizePopUp="0" AutoFlip="1" ScrollThreshold="96">
         <ButtonData>
           <Button ID="AerodromeButton" Anchor="C,C" Size="28,28" Offset="-14,0" NoStateChange="1">
@@ -316,7 +321,7 @@
         <ScrollPanelData Anchor="L,T" Vertical="1" Offset="0,0" AutoScrollBar="1">
           <ScrollBar Style="ScrollVerticalBacking" Anchor="L,T" AnchorSide="O,I" Color="28,60,90,255" Offset="1,0">
             <Thumb Style="ScrollThumbAlt" Color="28,60,90,255" />
-          </ScrollBar> 
+          </ScrollBar>
         </ScrollPanelData>
 
         <StackData StackGrowth="Down" Offset="0,0" Size="240,400" Anchor="L,T"/>
@@ -339,7 +344,7 @@
         <Grid ID="Banner_Darker"  Size="Parent,Parent" Texture="BannerMini_Darker" SliceCorner="18,9" SliceSize="44,16" SliceTextureSize="80,34"/>
         <Grid ID="Banner_Lighter" Size="Parent,Parent" Texture="BannerMini_Lighter" SliceCorner="18,9" SliceSize="44,16" SliceTextureSize="80,34"/>
         <Grid ID="Banner_None"    Size="Parent,Parent" Texture="BannerMini_None" SliceCorner="18,9" SliceSize="44,16" SliceTextureSize="80,34"/>
-        
+
         <!-- Nukes -->
         <Container Anchor="L,C" Offset="25,0">
           <Stack Offset="0,-1" Anchor="C,C" StackGrowth="Right" StackPadding="2,0">
@@ -377,7 +382,7 @@
 
         <!-- District Font Icon -->
         <Label Anchor="L,C" Offset="7,3" Style="FontNormal14" String="[Icon_DISTRICT_ENCAMPMENT]"/>
-        
+
         <!-- Healthbars -->
         <TextureBar ID="CityHealthBar"  Anchor="R,C" Offset="8,3"   Size="66,7" Texture="CityBannerShieldsBar1"     Direction="Right" Speed="1" Percent="1.0" />
         <TextureBar ID="CityDefenseBar" Anchor="R,C" Offset="8,-4"  Size="66,7" Texture="CityBannerShieldsBar1"     Direction="Right" Speed="1" Percent="1.0" Color="120,198,247,255"/>
@@ -397,7 +402,7 @@
       </Container>
     </WorldAnchor>
   </Instance>
-  
+
   <Instance       Name="ReligionChange">
     <AlphaAnim    ID="FadeAnim" AlphaStart="0" AlphaEnd="1" Speed="1" Cycle="Once" Offset="0,0" Anchor="C,C" Stopped="true" >
       <SlideAnim  ID="SlideAnim" Function="Root" Start="-5,5" End="-5,-5" Speed="2.5" Cycle="Once" Offset="0,0" Stopped="true" >
@@ -436,7 +441,7 @@
   <Instance Name="ReligionMeterHigh">
     <Meter ID="Meter" Size="110,110" Texture="Religion_MeterPressureHigh" Follow="1" />
   </Instance>
-  
+
   <Instance Name="PressureLow">
     <Image ID="PressureIcon" Size="10,14" Anchor="C,C" Texture="PressureLow" />
   </Instance>


### PR DESCRIPTION
Resolves #384 

This will show the leader icon in the city banner for the suzerain:
![image](https://cloud.githubusercontent.com/assets/381657/25783978/a3facdd0-3365-11e7-85e3-fdc86985d312.png) 
![image](https://cloud.githubusercontent.com/assets/381657/25783986/c4b8291e-3365-11e7-9aef-e407bdf00998.png)

If you have not met the leader yet it will be a question mark.

It seems like shifts of suzerains are handled in dll's so the InfluenceGiven event was the best I could come up with without tracking down all places that can cause a Suzerain shift. The bad thing is that it will fire one time for each envoy spent but it seems to not be a problem in my tests.

