### PR TITLE
Make city markers on the minimap smaller.

### DIFF
--- a/ArtDefs/Minimap.artdef
+++ b/ArtDefs/Minimap.artdef
@@ -42,7 +42,7 @@
         <m_Fields>
           <m_Values>
             <Element class="AssetObjects:FloatValue">
-              <m_fValue>11.000000</m_fValue>
+              <m_fValue>20.000000</m_fValue>
               <m_ParamName text="Width"/>
             </Element>
             <Element class="AssetObjects:RGBValue">

--- a/ArtDefs/Minimap.artdef
+++ b/ArtDefs/Minimap.artdef
@@ -42,7 +42,7 @@
 				<m_Fields>
 					<m_Values>
 						<Element class="AssetObjects:FloatValue">
-							<m_fValue>22.000000</m_fValue>
+							<m_fValue>11.000000</m_fValue>
 							<m_ParamName text="Width"/>
 						</Element>
 						<Element class="AssetObjects:RGBValue">
@@ -69,7 +69,7 @@
 				<m_Fields>
 					<m_Values>
 						<Element class="AssetObjects:FloatValue">
-							<m_fValue>30.000000</m_fValue>
+							<m_fValue>15.000000</m_fValue>
 							<m_ParamName text="Width"/>
 						</Element>
 						<Element class="AssetObjects:RGBValue">

--- a/ArtDefs/Minimap.artdef
+++ b/ArtDefs/Minimap.artdef
@@ -1,98 +1,98 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <AssetObjects:ArtDefSet>
-	<m_Version>
-		<major>3</major>
-		<minor>0</minor>
-		<build>186</build>
-		<revision>62</revision>
-	</m_Version>
-	<m_TemplateName text="Minimap"/>
-	<m_RootCollections>
-		<Element>
-			<m_CollectionName text="Frustum"/>
-			<m_ReplaceMergedCollectionElements>false</m_ReplaceMergedCollectionElements>
-			<Element>
-				<m_Fields>
-					<m_Values>
-						<Element class="AssetObjects:FloatValue">
-							<m_fValue>0.750000</m_fValue>
-							<m_ParamName text="Width"/>
-						</Element>
-						<Element class="AssetObjects:RGBValue">
-							<m_r>255.000000</m_r>
-							<m_g>255.000000</m_g>
-							<m_b>255.000000</m_b>
-							<m_ParamName text="Color"/>
-						</Element>
-						<Element class="AssetObjects:FloatValue">
-							<m_fValue>1.000000</m_fValue>
-							<m_ParamName text="Opacity"/>
-						</Element>
-					</m_Values>
-				</m_Fields>
-				<m_ChildCollections/>
-				<m_Name text="Default"/>
-				<m_AppendMergedParameterCollections>false</m_AppendMergedParameterCollections>
-			</Element>
-		</Element>
-		<Element>
-			<m_CollectionName text="Blip"/>
-			<m_ReplaceMergedCollectionElements>false</m_ReplaceMergedCollectionElements>
-			<Element>
-				<m_Fields>
-					<m_Values>
-						<Element class="AssetObjects:FloatValue">
-							<m_fValue>11.000000</m_fValue>
-							<m_ParamName text="Width"/>
-						</Element>
-						<Element class="AssetObjects:RGBValue">
-							<m_r>0.000000</m_r>
-							<m_g>255.000000</m_g>
-							<m_b>0.000000</m_b>
-							<m_ParamName text="Color"/>
-						</Element>
-						<Element class="AssetObjects:FloatValue">
-							<m_fValue>1.000000</m_fValue>
-							<m_ParamName text="Opacity"/>
-						</Element>
-						<Element class="AssetObjects:FloatValue">
-							<m_fValue>2.000000</m_fValue>
-							<m_ParamName text="FlashRate"/>
-						</Element>
-					</m_Values>
-				</m_Fields>
-				<m_ChildCollections/>
-				<m_Name text="CityBlip"/>
-				<m_AppendMergedParameterCollections>false</m_AppendMergedParameterCollections>
-			</Element>
-			<Element>
-				<m_Fields>
-					<m_Values>
-						<Element class="AssetObjects:FloatValue">
-							<m_fValue>15.000000</m_fValue>
-							<m_ParamName text="Width"/>
-						</Element>
-						<Element class="AssetObjects:RGBValue">
-							<m_r>0.000000</m_r>
-							<m_g>255.000000</m_g>
-							<m_b>0.000000</m_b>
-							<m_ParamName text="Color"/>
-						</Element>
-						<Element class="AssetObjects:FloatValue">
-							<m_fValue>1.000000</m_fValue>
-							<m_ParamName text="Opacity"/>
-						</Element>
-						<Element class="AssetObjects:FloatValue">
-							<m_fValue>2.000000</m_fValue>
-							<m_ParamName text="FlashRate"/>
-						</Element>
-					</m_Values>
-				</m_Fields>
-				<m_ChildCollections/>
-				<m_Name text="SelectedBlip"/>
-				<m_AppendMergedParameterCollections>false</m_AppendMergedParameterCollections>
-			</Element>
-		</Element>
-	</m_RootCollections>
+  <m_Version>
+    <major>3</major>
+    <minor>0</minor>
+    <build>186</build>
+    <revision>62</revision>
+  </m_Version>
+  <m_TemplateName text="Minimap"/>
+  <m_RootCollections>
+    <Element>
+      <m_CollectionName text="Frustum"/>
+      <m_ReplaceMergedCollectionElements>false</m_ReplaceMergedCollectionElements>
+      <Element>
+        <m_Fields>
+          <m_Values>
+            <Element class="AssetObjects:FloatValue">
+              <m_fValue>0.750000</m_fValue>
+              <m_ParamName text="Width"/>
+            </Element>
+            <Element class="AssetObjects:RGBValue">
+              <m_r>255.000000</m_r>
+              <m_g>255.000000</m_g>
+              <m_b>255.000000</m_b>
+              <m_ParamName text="Color"/>
+            </Element>
+            <Element class="AssetObjects:FloatValue">
+              <m_fValue>1.000000</m_fValue>
+              <m_ParamName text="Opacity"/>
+            </Element>
+          </m_Values>
+        </m_Fields>
+        <m_ChildCollections/>
+        <m_Name text="Default"/>
+        <m_AppendMergedParameterCollections>false</m_AppendMergedParameterCollections>
+      </Element>
+    </Element>
+    <Element>
+      <m_CollectionName text="Blip"/>
+      <m_ReplaceMergedCollectionElements>false</m_ReplaceMergedCollectionElements>
+      <Element>
+        <m_Fields>
+          <m_Values>
+            <Element class="AssetObjects:FloatValue">
+              <m_fValue>11.000000</m_fValue>
+              <m_ParamName text="Width"/>
+            </Element>
+            <Element class="AssetObjects:RGBValue">
+              <m_r>0.000000</m_r>
+              <m_g>255.000000</m_g>
+              <m_b>0.000000</m_b>
+              <m_ParamName text="Color"/>
+            </Element>
+            <Element class="AssetObjects:FloatValue">
+              <m_fValue>1.000000</m_fValue>
+              <m_ParamName text="Opacity"/>
+            </Element>
+            <Element class="AssetObjects:FloatValue">
+              <m_fValue>2.000000</m_fValue>
+              <m_ParamName text="FlashRate"/>
+            </Element>
+          </m_Values>
+        </m_Fields>
+        <m_ChildCollections/>
+        <m_Name text="CityBlip"/>
+        <m_AppendMergedParameterCollections>false</m_AppendMergedParameterCollections>
+      </Element>
+      <Element>
+        <m_Fields>
+          <m_Values>
+            <Element class="AssetObjects:FloatValue">
+              <m_fValue>15.000000</m_fValue>
+              <m_ParamName text="Width"/>
+            </Element>
+            <Element class="AssetObjects:RGBValue">
+              <m_r>0.000000</m_r>
+              <m_g>255.000000</m_g>
+              <m_b>0.000000</m_b>
+              <m_ParamName text="Color"/>
+            </Element>
+            <Element class="AssetObjects:FloatValue">
+              <m_fValue>1.000000</m_fValue>
+              <m_ParamName text="Opacity"/>
+            </Element>
+            <Element class="AssetObjects:FloatValue">
+              <m_fValue>2.000000</m_fValue>
+              <m_ParamName text="FlashRate"/>
+            </Element>
+          </m_Values>
+        </m_Fields>
+        <m_ChildCollections/>
+        <m_Name text="SelectedBlip"/>
+        <m_AppendMergedParameterCollections>false</m_AppendMergedParameterCollections>
+      </Element>
+    </Element>
+  </m_RootCollections>
 </AssetObjects:ArtDefSet>
 

--- a/ArtDefs/Minimap.artdef
+++ b/ArtDefs/Minimap.artdef
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<AssetObjects:ArtDefSet>
+	<m_Version>
+		<major>3</major>
+		<minor>0</minor>
+		<build>186</build>
+		<revision>62</revision>
+	</m_Version>
+	<m_TemplateName text="Minimap"/>
+	<m_RootCollections>
+		<Element>
+			<m_CollectionName text="Frustum"/>
+			<m_ReplaceMergedCollectionElements>false</m_ReplaceMergedCollectionElements>
+			<Element>
+				<m_Fields>
+					<m_Values>
+						<Element class="AssetObjects:FloatValue">
+							<m_fValue>0.750000</m_fValue>
+							<m_ParamName text="Width"/>
+						</Element>
+						<Element class="AssetObjects:RGBValue">
+							<m_r>255.000000</m_r>
+							<m_g>255.000000</m_g>
+							<m_b>255.000000</m_b>
+							<m_ParamName text="Color"/>
+						</Element>
+						<Element class="AssetObjects:FloatValue">
+							<m_fValue>1.000000</m_fValue>
+							<m_ParamName text="Opacity"/>
+						</Element>
+					</m_Values>
+				</m_Fields>
+				<m_ChildCollections/>
+				<m_Name text="Default"/>
+				<m_AppendMergedParameterCollections>false</m_AppendMergedParameterCollections>
+			</Element>
+		</Element>
+		<Element>
+			<m_CollectionName text="Blip"/>
+			<m_ReplaceMergedCollectionElements>false</m_ReplaceMergedCollectionElements>
+			<Element>
+				<m_Fields>
+					<m_Values>
+						<Element class="AssetObjects:FloatValue">
+							<m_fValue>22.000000</m_fValue>
+							<m_ParamName text="Width"/>
+						</Element>
+						<Element class="AssetObjects:RGBValue">
+							<m_r>0.000000</m_r>
+							<m_g>255.000000</m_g>
+							<m_b>0.000000</m_b>
+							<m_ParamName text="Color"/>
+						</Element>
+						<Element class="AssetObjects:FloatValue">
+							<m_fValue>1.000000</m_fValue>
+							<m_ParamName text="Opacity"/>
+						</Element>
+						<Element class="AssetObjects:FloatValue">
+							<m_fValue>2.000000</m_fValue>
+							<m_ParamName text="FlashRate"/>
+						</Element>
+					</m_Values>
+				</m_Fields>
+				<m_ChildCollections/>
+				<m_Name text="CityBlip"/>
+				<m_AppendMergedParameterCollections>false</m_AppendMergedParameterCollections>
+			</Element>
+			<Element>
+				<m_Fields>
+					<m_Values>
+						<Element class="AssetObjects:FloatValue">
+							<m_fValue>30.000000</m_fValue>
+							<m_ParamName text="Width"/>
+						</Element>
+						<Element class="AssetObjects:RGBValue">
+							<m_r>0.000000</m_r>
+							<m_g>255.000000</m_g>
+							<m_b>0.000000</m_b>
+							<m_ParamName text="Color"/>
+						</Element>
+						<Element class="AssetObjects:FloatValue">
+							<m_fValue>1.000000</m_fValue>
+							<m_ParamName text="Opacity"/>
+						</Element>
+						<Element class="AssetObjects:FloatValue">
+							<m_fValue>2.000000</m_fValue>
+							<m_ParamName text="FlashRate"/>
+						</Element>
+					</m_Values>
+				</m_Fields>
+				<m_ChildCollections/>
+				<m_Name text="SelectedBlip"/>
+				<m_AppendMergedParameterCollections>false</m_AppendMergedParameterCollections>
+			</Element>
+		</Element>
+	</m_RootCollections>
+</AssetObjects:ArtDefSet>
+

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Those looking to contribute to CQUI should visit [the CQUI repo](https://github.
 * @velit for a UI bugfix in #138
 * @the-m4a for a patch incompatibility bugfix in #181
 * @MarkusKV for fixing a bug concerning district completion checkboxes
+* @apskim for changing the style of city markers on the minimap
 * Firaxis for eventually delivering mod tools and steam workshop ;)
 * The lovely folks over at Civfanatics for their guides, knowledge, tools, and resources
 * The even lovelier folks over at /r/civ for their input and testing

--- a/cqui.dep
+++ b/cqui.dep
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<AssetObjects::GameDependencyData>
+	<ID>
+		<name text="Chao's Quick UI" />
+		<id text="4ffb3526-42c7-4b36-818c-f889d49aec76" />
+	</ID>
+	<SystemDependencies>
+		<Element>
+			<ConsumerName text="Minimap"/>
+			<ArtDefDependencyPaths>
+				<Element text="Minimap.artdef"/>
+			</ArtDefDependencyPaths>
+			<LibraryDependencies/>
+			<LoadsLibraries>false</LoadsLibraries>
+		</Element>
+	</SystemDependencies>
+</AssetObjects::GameDependencyData>

--- a/cqui.dep
+++ b/cqui.dep
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <AssetObjects::GameDependencyData>
-	<ID>
-		<name text="Chao's Quick UI" />
-		<id text="4ffb3526-42c7-4b36-818c-f889d49aec76" />
-	</ID>
-	<SystemDependencies>
-		<Element>
-			<ConsumerName text="Minimap"/>
-			<ArtDefDependencyPaths>
-				<Element text="Minimap.artdef"/>
-			</ArtDefDependencyPaths>
-			<LibraryDependencies/>
-			<LoadsLibraries>false</LoadsLibraries>
-		</Element>
-	</SystemDependencies>
+  <ID>
+    <name text="Chao's Quick UI" />
+    <id text="4ffb3526-42c7-4b36-818c-f889d49aec76" />
+  </ID>
+  <SystemDependencies>
+    <Element>
+      <ConsumerName text="Minimap"/>
+      <ArtDefDependencyPaths>
+        <Element text="Minimap.artdef"/>
+      </ArtDefDependencyPaths>
+      <LibraryDependencies/>
+      <LoadsLibraries>false</LoadsLibraries>
+    </Element>
+  </SystemDependencies>
 </AssetObjects::GameDependencyData>

--- a/cqui.modinfo
+++ b/cqui.modinfo
@@ -94,6 +94,7 @@
 
   <!-- Complete File Manifest -->
   <Files>
+    <File>cqui.dep</File>
     <File>Assets/cqui_databaseschema.sql</File>
     <File>Assets/cqui_settings.sql</File>
     <File>Assets/cqui_settings_local.sql</File>
@@ -336,6 +337,12 @@
         <File>Assets/cqui_main.lua</File>
       </Items>
     </GameplayScripts>
+    <!-- CQUI specific art overrides -->
+    <ModArt id="CQUI_MODART">
+      <Items>
+        <File>cqui.dep</File>
+      </Items>
+    </ModArt>
 
     <!-- Mod integrations -->
     <LocalizedText id="BTS_TEXT">

--- a/cqui.modinfo
+++ b/cqui.modinfo
@@ -5,7 +5,7 @@
     <Name>Chao's Quick UI</Name>
     <Teaser>CQUI_TEASER</Teaser>
     <Description>CQUI_TEASER</Description>
-    <Authors>vans163, chaorace, zgavin, olegbl, jacks0n, OfekA, Proustldee, RatchetJ, kblease, benjaminjackman, LordYanaek, zeyangl, velit, the-m4a, Frozen-In-Ice, Remolten, bestekov, bolbass, SpaceOgre, cpinter, JHCD, paavohuhtala, Aristos, MarkusKV</Authors>
+    <Authors>vans163, chaorace, zgavin, olegbl, jacks0n, OfekA, Proustldee, RatchetJ, kblease, benjaminjackman, LordYanaek, zeyangl, velit, the-m4a, Frozen-In-Ice, Remolten, bestekov, bolbass, SpaceOgre, cpinter, JHCD, paavohuhtala, Aristos, MarkusKV, apskim</Authors>
     <SpecialThanks>vans163 for his original qui mod.[NEWLINE]astog for his Better Trade Screen mod.[NEWLINE]astog for his More Lenses mod.[NEWLINE]Ace for his Next City Plot mod.[NEWLINE]Divine Yuri for his Custom City Panel mod.[NEWLINE]Greg Miller for his Unit Report Screen mod.[NEWLINE]Lozenged/kblease for his Production Queue mod.[NEWLINE]mironos for his Improved Deal Screen mod.[NEWLINE]HellBlazer for parts of his NQ EUI mod.[NEWLINE]ZhouYzzz for providing the Chinese translation.[NEWLINE]Simone1974 for providing the Italian translation.[NEWLINE]e1ectron for providing the Russian translation.[NEWLINE]sejbr for providing the Polish translation.[NEWLINE]frytom/maxap/JHCD for providing the German translation.[NEWLINE]lctrs for providing a partial French translation.[NEWLINE]wbqd for providing the Korean translation.</SpecialThanks>
     <Stability>CQUI_STABILITY_NIGHTLY</Stability>
   </Properties>


### PR DESCRIPTION
This PR reduces the size of giant square city markers on the minimap. This is one of the oft-requested features on /r/civ and other communities.

Screenshot:
![minimap](https://cloud.githubusercontent.com/assets/852687/25983387/5a767bf0-3699-11e7-9fb3-c59959f26552.png)

Special thanks to NQ EUI, which already has this feature implemented, and which gave me an idea to add this to CQUI.
(Note: Should I add HellBlazer to the acknowledgments?)