### PR TITLE
Update all cities data when swap tiles

### DIFF
--- a/Assets/UI/WorldView/plotinfo.lua
+++ b/Assets/UI/WorldView/plotinfo.lua
@@ -962,9 +962,9 @@ function CQUI_UpdateAllCitiesCitizens()
 
   local m_pCity:table = Players[Game.GetLocalPlayer()]:GetCities();
   for i, pCity in m_pCity:Members() do
-    local pCitizens   :table = pCity:GetCitizens();
-    
+    local pCitizens   :table = pCity:GetCitizens();    
     local tParameters :table = {};
+    
     if pCitizens:IsFavoredYield(YieldTypes.CULTURE) then
       tParameters[CityCommandTypes.PARAM_FLAGS]   = 0;      -- Set favoured
       tParameters[CityCommandTypes.PARAM_DATA0] = 1;          -- on

--- a/Assets/UI/WorldView/plotinfo.lua
+++ b/Assets/UI/WorldView/plotinfo.lua
@@ -960,26 +960,25 @@ end
 -- CQUI update all cities citizens and data when swap tiles
 function CQUI_UpdateAllCitiesCitizens()
 
-	local m_pCity:table = Players[Game.GetLocalPlayer()]:GetCities();
-	for i, pCity in m_pCity:Members() do
-
-		local pCitizens   :table = pCity:GetCitizens();
-		local tParameters :table = {};
-
-		if pCitizens:IsFavoredYield(YieldTypes.CULTURE) then
-			tParameters[CityCommandTypes.PARAM_FLAGS]   = 0;      -- Set favoured
-			tParameters[CityCommandTypes.PARAM_DATA0] = 1;          -- on
-		elseif pCitizens:IsDisfavoredYield(YieldTypes.CULTURE) then
-			tParameters[CityCommandTypes.PARAM_FLAGS]   = 1;      -- Set Ignored
-			tParameters[CityCommandTypes.PARAM_DATA0] = 1;          -- on
-		else
-			tParameters[CityCommandTypes.PARAM_FLAGS]   = 0;      -- Set favoured
-			tParameters[CityCommandTypes.PARAM_DATA0] = 0;          -- off
-		end
-      
-		tParameters[CityCommandTypes.PARAM_YIELD_TYPE]= yieldType;  -- Yield type
-		CityManager.RequestCommand(pCity, CityCommandTypes.SET_FOCUS, tParameters);
-	end
+  local m_pCity:table = Players[Game.GetLocalPlayer()]:GetCities();
+  for i, pCity in m_pCity:Members() do
+    local pCitizens   :table = pCity:GetCitizens();
+    
+    local tParameters :table = {};
+    if pCitizens:IsFavoredYield(YieldTypes.CULTURE) then
+      tParameters[CityCommandTypes.PARAM_FLAGS]   = 0;      -- Set favoured
+      tParameters[CityCommandTypes.PARAM_DATA0] = 1;          -- on
+    elseif pCitizens:IsDisfavoredYield(YieldTypes.CULTURE) then
+      tParameters[CityCommandTypes.PARAM_FLAGS]   = 1;      -- Set Ignored
+      tParameters[CityCommandTypes.PARAM_DATA0] = 1;          -- on
+    else
+      tParameters[CityCommandTypes.PARAM_FLAGS]   = 0;      -- Set favoured
+      tParameters[CityCommandTypes.PARAM_DATA0] = 0;          -- off
+    end
+    
+    tParameters[CityCommandTypes.PARAM_YIELD_TYPE]= yieldType;  -- Yield type
+    CityManager.RequestCommand(pCity, CityCommandTypes.SET_FOCUS, tParameters);
+  end
 end
 
 -- ===========================================================================

--- a/Assets/UI/WorldView/plotinfo.lua
+++ b/Assets/UI/WorldView/plotinfo.lua
@@ -77,9 +77,10 @@ function OnClickSwapTile( plotId:number )
   tParameters[CityCommandTypes.PARAM_Y] = kPlot:GetY();
 
   local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.SWAP_TILE_OWNER, tParameters );
-  -- CQUI_UpdateSelectedCityCitizens
-  OnClickCitizen();
-  CQUI_UpdateAllCitiesCitizens();    -- CQUI update all cities data when swap
+  
+  OnClickCitizen();    -- CQUI update selected city citizens and data
+  CQUI_UpdateAllCitiesCitizens();    -- CQUI update all cities data when swap tiles
+  
   return true;
 end
 
@@ -111,8 +112,9 @@ function OnClickPurchasePlot( plotId:number )
   --     after a plot puchase (e.g., buying plot for district placement)
   --     you must wait for the event raised from the gamecore before figuring
   --     out which plots need a display.
-  -- CQUI_UpdateSelectedCityCitizens
-  OnClickCitizen();
+  
+  OnClickCitizen();    -- CQUI update selected city citizens and data
+  
   return true;
 end
 

--- a/Assets/UI/WorldView/plotinfo.lua
+++ b/Assets/UI/WorldView/plotinfo.lua
@@ -77,10 +77,7 @@ function OnClickSwapTile( plotId:number )
   tParameters[CityCommandTypes.PARAM_Y] = kPlot:GetY();
 
   local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.SWAP_TILE_OWNER, tParameters );
-  
-  OnClickCitizen();    -- CQUI update selected city citizens and data
   CQUI_UpdateAllCitiesCitizens();    -- CQUI update all cities data when swap tiles
-  
   return true;
 end
 
@@ -114,7 +111,6 @@ function OnClickPurchasePlot( plotId:number )
   --     out which plots need a display.
   
   OnClickCitizen();    -- CQUI update selected city citizens and data
-  
   return true;
 end
 

--- a/Assets/UI/WorldView/plotinfo.lua
+++ b/Assets/UI/WorldView/plotinfo.lua
@@ -972,7 +972,7 @@ function CQUI_UpdateAllCitiesCitizens()
 
 		if pCitizens:IsFavoredYield(YieldTypes.CULTURE) then
 			tParameters[CityCommandTypes.PARAM_FLAGS]   = 0;      -- Set favoured
-       			tParameters[CityCommandTypes.PARAM_DATA0] = 1;          -- on
+      tParameters[CityCommandTypes.PARAM_DATA0] = 1;          -- on
      		elseif pCitizens:IsDisfavoredYield(YieldTypes.CULTURE) then
 			tParameters[CityCommandTypes.PARAM_FLAGS]   = 1;      -- Set Ignored
 			tParameters[CityCommandTypes.PARAM_DATA0] = 1;          -- on

--- a/Assets/UI/WorldView/plotinfo.lua
+++ b/Assets/UI/WorldView/plotinfo.lua
@@ -77,7 +77,7 @@ function OnClickSwapTile( plotId:number )
   tParameters[CityCommandTypes.PARAM_Y] = kPlot:GetY();
 
   local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.SWAP_TILE_OWNER, tParameters );
-  CQUI_UpdateAllCitiesCitizens();    -- CQUI update all cities data when swap tiles
+  CQUI_UpdateAllCitiesCitizens();    -- CQUI update all cities citizens and data when swap tiles
   return true;
 end
 
@@ -957,7 +957,7 @@ function OnInputHandler( pInputStruct:table )
 end
 
 -- ===========================================================================
--- CQUI update all cities data when swap tiles
+-- CQUI update all cities citizens and data when swap tiles
 function CQUI_UpdateAllCitiesCitizens()
 
 	local m_pCity:table = Players[Game.GetLocalPlayer()]:GetCities();
@@ -968,8 +968,8 @@ function CQUI_UpdateAllCitiesCitizens()
 
 		if pCitizens:IsFavoredYield(YieldTypes.CULTURE) then
 			tParameters[CityCommandTypes.PARAM_FLAGS]   = 0;      -- Set favoured
-      tParameters[CityCommandTypes.PARAM_DATA0] = 1;          -- on
-     		elseif pCitizens:IsDisfavoredYield(YieldTypes.CULTURE) then
+			tParameters[CityCommandTypes.PARAM_DATA0] = 1;          -- on
+    elseif pCitizens:IsDisfavoredYield(YieldTypes.CULTURE) then
 			tParameters[CityCommandTypes.PARAM_FLAGS]   = 1;      -- Set Ignored
 			tParameters[CityCommandTypes.PARAM_DATA0] = 1;          -- on
 		else

--- a/Assets/UI/WorldView/plotinfo.lua
+++ b/Assets/UI/WorldView/plotinfo.lua
@@ -77,6 +77,7 @@ function OnClickSwapTile( plotId:number )
   tParameters[CityCommandTypes.PARAM_Y] = kPlot:GetY();
 
   local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.SWAP_TILE_OWNER, tParameters );
+  
   CQUI_UpdateAllCitiesCitizens();    -- CQUI update all cities citizens and data when swap tiles
   return true;
 end

--- a/Assets/UI/WorldView/plotinfo.lua
+++ b/Assets/UI/WorldView/plotinfo.lua
@@ -79,6 +79,7 @@ function OnClickSwapTile( plotId:number )
   local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.SWAP_TILE_OWNER, tParameters );
   -- CQUI_UpdateSelectedCityCitizens
   OnClickCitizen();
+  CQUI_UpdateAllCitiesCitizens();    -- CQUI update all cities data when swap
   return true;
 end
 
@@ -955,6 +956,32 @@ function OnInputHandler( pInputStruct:table )
   local uiMsg = pInputStruct:GetMessageType();
   if (uiMsg == KeyEvents.KeyUp) then return KeyHandler( pInputStruct:GetKey() ); end;
   return false;
+end
+
+-- ===========================================================================
+-- CQUI update all cities data when swap tiles
+function CQUI_UpdateAllCitiesCitizens()
+
+	local m_pCity:table = Players[Game.GetLocalPlayer()]:GetCities();
+	for i, pCity in m_pCity:Members() do
+
+		local pCitizens   :table = pCity:GetCitizens();
+		local tParameters :table = {};
+
+		if pCitizens:IsFavoredYield(YieldTypes.CULTURE) then
+			tParameters[CityCommandTypes.PARAM_FLAGS]   = 0;      -- Set favoured
+       			tParameters[CityCommandTypes.PARAM_DATA0] = 1;          -- on
+     		elseif pCitizens:IsDisfavoredYield(YieldTypes.CULTURE) then
+			tParameters[CityCommandTypes.PARAM_FLAGS]   = 1;      -- Set Ignored
+			tParameters[CityCommandTypes.PARAM_DATA0] = 1;          -- on
+		else
+			tParameters[CityCommandTypes.PARAM_FLAGS]   = 0;      -- Set favoured
+			tParameters[CityCommandTypes.PARAM_DATA0] = 0;          -- off
+		end
+      
+		tParameters[CityCommandTypes.PARAM_YIELD_TYPE]= yieldType;  -- Yield type
+		CityManager.RequestCommand(pCity, CityCommandTypes.SET_FOCUS, tParameters);
+	end
 end
 
 -- ===========================================================================

--- a/Assets/UI/WorldView/plotinfo.lua
+++ b/Assets/UI/WorldView/plotinfo.lua
@@ -969,7 +969,7 @@ function CQUI_UpdateAllCitiesCitizens()
 		if pCitizens:IsFavoredYield(YieldTypes.CULTURE) then
 			tParameters[CityCommandTypes.PARAM_FLAGS]   = 0;      -- Set favoured
 			tParameters[CityCommandTypes.PARAM_DATA0] = 1;          -- on
-    elseif pCitizens:IsDisfavoredYield(YieldTypes.CULTURE) then
+		elseif pCitizens:IsDisfavoredYield(YieldTypes.CULTURE) then
 			tParameters[CityCommandTypes.PARAM_FLAGS]   = 1;      -- Set Ignored
 			tParameters[CityCommandTypes.PARAM_DATA0] = 1;          -- on
 		else


### PR DESCRIPTION
All cities data now updates on fly when we swap tiles. In addition to 562368fcba1991e6e64fcee78a0bfa1e24a1bb0d it solves #247. And I think we can revert some changes from #279 because it seems that we don't need to update city's data on clicking citybanner, next/prev city buttons and hotkeys anymore. It's already updated every time we enter cityview.