### PR TITLE
Revert unnecessary autoupdate citizen

### DIFF
--- a/Assets/UI/Panels/citypanel.lua
+++ b/Assets/UI/Panels/citypanel.lua
@@ -185,15 +185,13 @@ end
 function CQUI_OnNextCity()
   local kCity:table = UI.GetHeadSelectedCity();
   UI.SelectNextCity(kCity);
-  UI.PlaySound("UI_Click_Sweetener_Metal_Button_Small");
-  CQUI_UpdateSelectedCityCitizens();
+  UI.PlaySound("UI_Click_Sweetener_Metal_Button_Small");  
 end
 
 function CQUI_OnPreviousCity()
   local kCity:table = UI.GetHeadSelectedCity();
   UI.SelectPrevCity(kCity);
-  UI.PlaySound("UI_Click_Sweetener_Metal_Button_Small");
-  CQUI_UpdateSelectedCityCitizens();
+  UI.PlaySound("UI_Click_Sweetener_Metal_Button_Small");  
 end
 
 function CQUI_OnLoadScreenClose()

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -1316,8 +1316,7 @@ function OnCityBannerClick( playerID:number, cityID:number )
       end
     end
 
-  end
-  CQUI_UpdateSelectedCityCitizens();
+  end  
 end
 
 -- ===========================================================================
@@ -3211,20 +3210,6 @@ function OnInterfaceModeChanged( oldMode:number, newMode:number )
       end
     end
   end
-end
-
--- ===========================================================================
-function CQUI_UpdateSelectedCityCitizens( plotId:number )
-
-  local pSelectedCity	:table = UI.GetHeadSelectedCity();
-  local kPlot			:table = Map.GetPlotByIndex(plotId);
-  local tParameters	:table = {};
-  tParameters[CityCommandTypes.PARAM_MANAGE_CITIZEN] = UI.GetInterfaceModeParameter(CityCommandTypes.PARAM_MANAGE_CITIZEN);
-  tParameters[CityCommandTypes.PARAM_X] = kPlot:GetX();
-  tParameters[CityCommandTypes.PARAM_Y] = kPlot:GetY();
-
-  local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.MANAGE, tParameters );
-  return true;
 end
 
 -- ===========================================================================

--- a/Assets/UI/worldinput.lua
+++ b/Assets/UI/worldinput.lua
@@ -3430,31 +3430,15 @@ function OnInputActionTriggered( actionId )
         UI.PlaySound("Play_UI_Click");
     elseif actionId == m_actionHotkeyPrevCity then
         LuaEvents.CQUI_GoPrevCity();
-        UI.PlaySound("Play_UI_Click");
-        CQUI_UpdateSelectedCityCitizens();
+        UI.PlaySound("Play_UI_Click");        
     elseif actionId == m_actionHotkeyNextCity then
         LuaEvents.CQUI_GoNextCity();
-        UI.PlaySound("Play_UI_Click");
-        CQUI_UpdateSelectedCityCitizens();
+        UI.PlaySound("Play_UI_Click");        
     elseif actionId == m_actionHotkeyOnlinePause then
         if GameConfiguration.IsNetworkMultiplayer() then
             TogglePause();
         end
     end
-end
-
--- ===========================================================================
-function CQUI_UpdateSelectedCityCitizens( plotId:number )
-
-	local pSelectedCity	:table = UI.GetHeadSelectedCity();
-	local kPlot			:table = Map.GetPlotByIndex(plotId);
-	local tParameters	:table = {};
-	tParameters[CityCommandTypes.PARAM_MANAGE_CITIZEN] = UI.GetInterfaceModeParameter(CityCommandTypes.PARAM_MANAGE_CITIZEN);
-	tParameters[CityCommandTypes.PARAM_X] = kPlot:GetX();
-	tParameters[CityCommandTypes.PARAM_Y] = kPlot:GetY();
-
-	local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.MANAGE, tParameters );
-	return true;
 end
 
 -- ===========================================================================


### PR DESCRIPTION
We don't need to update city's data on clicking citybanner, next/prev city buttons and hotkeys #279 anymore as soon as data is already updated with #535 and 562368fcba1991e6e64fcee78a0bfa1e24a1bb0d