### PR TITLE
BTS - fix trade panel crashes when no available traders

### DIFF
--- a/Integrations/BTS/UI/tradeoverview.lua
+++ b/Integrations/BTS/UI/tradeoverview.lua
@@ -781,7 +781,7 @@ function AddRouteInstanceFromRouteInfo( routeInfo:table )
             );
         end
     end
-  
+
     local tradeUnit:table = originPlayer:GetUnits():FindID(routeInfo.TraderUnitID);
     if routeInfo.TraderUnitID then        
         routeInstance.GridButton:RegisterCallback( Mouse.eLClick,

--- a/Integrations/BTS/UI/tradeoverview.lua
+++ b/Integrations/BTS/UI/tradeoverview.lua
@@ -781,9 +781,9 @@ function AddRouteInstanceFromRouteInfo( routeInfo:table )
             );
         end
     end
-
-    if routeInfo.TraderUnitID then
-        local tradeUnit:table = originPlayer:GetUnits():FindID(routeInfo.TraderUnitID);
+  
+    local tradeUnit:table = originPlayer:GetUnits():FindID(routeInfo.TraderUnitID);
+    if routeInfo.TraderUnitID then        
         routeInstance.GridButton:RegisterCallback( Mouse.eLClick,
             function()
                 SelectUnit(tradeUnit);
@@ -802,6 +802,7 @@ function AddRouteInstanceFromRouteInfo( routeInfo:table )
                 end
             );
         else -- Cycle through all traders
+          if tradeUnit then
             local co = coroutine.create(
                 function()
                     while true do -- Infinitely cycle
@@ -822,6 +823,7 @@ function AddRouteInstanceFromRouteInfo( routeInfo:table )
                     CycleTraders(co)
                 end
             );
+          end
         end
     end
 end


### PR DESCRIPTION
Fixes #549 when game crashes if we try to choose trade routes since we have no available traders to make these routes.