### PR TITLE
Real housing fix, lowercase City panel text to fit housing info

### DIFF
--- a/Assets/UI/Panels/citypanel.lua
+++ b/Assets/UI/Panels/citypanel.lua
@@ -592,7 +592,9 @@ function ViewMain( data:table )
 
   Controls.ReligionNum:SetText( data.ReligionFollowers );
 
-  local CQUI_HousingFromImprovements = CQUI_RealHousingFromImprovements(selectedCity);    -- CQUI calculate real housing from improvements
+  -- CQUI get real housing from improvements value
+  local selectedCityID = selectedCity:GetID();
+  local CQUI_HousingFromImprovements = CQUI_HousingFromImprovementsTable[selectedCityID];  
   Controls.HousingNum:SetText( data.Population );
   colorName = GetPercentGrowthColor( data.HousingMultiplier );
   Controls.HousingNum:SetColorByName( colorName );
@@ -1326,6 +1328,13 @@ function CQUI_UpdateSelectedCityCitizens( plotId:number )
 end
 
 -- ===========================================================================
+--CQUI get real housing from improvements
+local CQUI_HousingFromImprovementsTable :table = {};
+function CQUI_HousingFromImprovementsTableInsert (pCityID, CQUI_HousingFromImprovements)
+  CQUI_HousingFromImprovementsTable[pCityID] = CQUI_HousingFromImprovements;
+end
+
+-- ===========================================================================
 --  CTOR
 -- ===========================================================================
 function Initialize()
@@ -1406,6 +1415,7 @@ function Initialize()
   LuaEvents.CQUI_ToggleGrowthTile.Add( CQUI_ToggleGrowthTile );
   LuaEvents.CQUI_SettingsUpdate.Add( CQUI_SettingsUpdate );
   LuaEvents.RefreshCityPanel.Add(Refresh);
+  LuaEvents.CQUI_RealHousingFromImprovementsCalculated.Add(CQUI_HousingFromImprovementsTableInsert);    --CQUI get real housing from improvements values
 
   -- Truncate possible static text overflows
   TruncateStringWithTooltip(Controls.BreakdownLabel,  MAX_BEFORE_TRUNC_STATIC_LABELS, Controls.BreakdownLabel:GetText());

--- a/Assets/UI/Panels/citypanel.lua
+++ b/Assets/UI/Panels/citypanel.lua
@@ -62,6 +62,8 @@ local m_secondaryColor        :number = 0xf00d1ace;
 local m_kTutorialDisabledControls :table  = nil;
 local m_GrowthPlot          :number = -1;
 
+local CQUI_HousingFromImprovementsTable :table = {};
+
 -- ====================CQUI Cityview==========================================
 
 local CQUI_cityview = false;
@@ -1329,7 +1331,6 @@ end
 
 -- ===========================================================================
 --CQUI get real housing from improvements
-local CQUI_HousingFromImprovementsTable :table = {};
 function CQUI_HousingFromImprovementsTableInsert (pCityID, CQUI_HousingFromImprovements)
   CQUI_HousingFromImprovementsTable[pCityID] = CQUI_HousingFromImprovements;
 end

--- a/Assets/UI/Panels/citypanel.xml
+++ b/Assets/UI/Panels/citypanel.xml
@@ -11,15 +11,15 @@
             <Image                                    Anchor="R,B" Offset="0,-7"                                Texture="SelectionPanel_Divider"  />
             <Grid           ID="BreakdownGrid"        Anchor="R,T" Offset="4,20"    Size="parent-100,20"        Style="CityPanelSlotGrid">
               <Label        ID="BreakdownNum"         Anchor="L,C" Offset="33,1"    Style="CityPanelNumLarge"   String="-" />
-              <Label        ID="BreakdownLabel"       Anchor="R,C" Offset="4,1"     Style="CityPanelHeader"     String="{LOC_HUD_DISTRICTS:upper}" />
+              <Label        ID="BreakdownLabel"       Anchor="R,C" Offset="4,1"     Style="CityPanelHeader"     String="{LOC_HUD_DISTRICTS}" />
             </Grid>
             <Grid           ID="ReligionGrid"         Anchor="R,T" Offset="4,45"    Size="parent-100,20"        Style="CityPanelSlotGrid">
               <Label        ID="ReligionNum"          Anchor="L,C" Offset="33,1"    Style="CityPanelNumLarge"   String="-" />
-              <Label        ID="ReligionLabel"        Anchor="R,C" Offset="4,1"     Style="CityPanelHeader"     String="{LOC_HUD_CITY_RELIGIOUS_CITIZENS:upper}" />
+              <Label        ID="ReligionLabel"        Anchor="R,C" Offset="4,1"     Style="CityPanelHeader"     String="{LOC_HUD_CITY_RELIGIOUS_CITIZENS}" />
             </Grid>
             <Grid           ID="AmenitiesGrid"        Anchor="R,T" Offset="4,71"    Size="parent-100,20"        Style="CityPanelSlotGrid">
               <Label        ID="AmenitiesNum"         Anchor="L,C" Offset="34,1"    Style="CityPanelNumLarge"   String="-" />
-              <Label        ID="AmenitiesLabel"       Anchor="R,C" Offset="4,1"     Style="CityPanelHeader"     String="{LOC_HUD_CITY_AMENITIES:upper}" />
+              <Label        ID="AmenitiesLabel"       Anchor="R,C" Offset="4,1"     Style="CityPanelHeader"     String="{LOC_HUD_CITY_AMENITIES}" />
             </Grid>
             <Grid           ID="HousingGrid"          Anchor="R,T" Offset="4,94"    Size="parent-100,20"        Style="CityPanelSlotGrid">
               <Stack                                               Offset="13,1"    StackGrowth="Right" >
@@ -27,7 +27,7 @@
                 <Label                                Anchor="L,C" Offset="1,0"     Style="CityPanelNumSmall"   String="/" />
                 <Label      ID="HousingMax"           Anchor="L,C" Offset="0,1"     Style="CityPanelNumSmall"   String="-" />
               </Stack>
-              <Label        ID="HousingLabel"         Anchor="R,C" Offset="4,1"     Style="CityPanelHeader"     String="{LOC_HUD_CITY_HOUSING_CAPACITY:upper}" />
+              <Label        ID="HousingLabel"         Anchor="R,C" Offset="4,1"     Style="CityPanelHeader"     String="{LOC_HUD_CITY_HOUSING_CAPACITY}" />
             </Grid>
             <Image          ID="GrowthTurnsSmall"     Anchor="L,B" Offset="82,-4"   Size="71,21"                Texture="CityPanel_MeterSmallBacking"   Hidden="1"  >
               <TextureBar   ID="GrowthTurnsBarSmall"  Anchor="L,T" Offset="2,2"     Size="parent-4,parent-3"    Texture="CityPanel_CitizenMeterSmall"   ShadowColor="255,255,255,100" />

--- a/Assets/UI/Panels/citypaneloverview.lua
+++ b/Assets/UI/Panels/citypaneloverview.lua
@@ -72,6 +72,8 @@ local ms_eventID = 0;
 local m_tabs;
 local m_isShowingPanel    :boolean = false;
 
+local CQUI_HousingFromImprovementsTable :table = {};
+
 -- ====================CQUI Cityview==========================================
 
   function CQUI_OnCityviewEnabled()
@@ -907,7 +909,6 @@ end
 
 -- ===========================================================================
 --CQUI get real housing from improvements
-local CQUI_HousingFromImprovementsTable :table = {};
 function CQUI_HousingFromImprovementsTableInsert (pCityID, CQUI_HousingFromImprovements)
   CQUI_HousingFromImprovementsTable[pCityID] = CQUI_HousingFromImprovements;
 end

--- a/Assets/UI/Panels/citypaneloverview.lua
+++ b/Assets/UI/Panels/citypaneloverview.lua
@@ -488,8 +488,10 @@ end
 -- ===========================================================================
 function ViewPanelHousing( data:table )
 
+  -- CQUI get real housing from improvements value
   local selectedCity  = UI.GetHeadSelectedCity();
-  local CQUI_HousingFromImprovements = CQUI_RealHousingFromImprovements(selectedCity);    -- CQUI calculate real housing from improvements
+  local selectedCityID = selectedCity:GetID();
+  local CQUI_HousingFromImprovements = CQUI_HousingFromImprovementsTable[selectedCityID];
 
   -- Only show the advisor bubbles during the tutorial
   Controls.HousingAdvisorBubble:SetHide( IsTutorialRunning() == false );
@@ -512,7 +514,7 @@ function ViewPanelHousing( data:table )
   CQUI_BuildHousingBubbleInstance("ICON_GREAT_PERSON_CLASS_SCIENTIST", data.HousingFromStartingEra, "LOC_ERA_NAME");
 
   local colorName:string = GetPercentGrowthColor( data.HousingMultiplier ) ;
-  Controls.HousingTotalNum:SetText( data.Housing - data.HousingFromImprovements + CQUI_HousingFromImprovements );    -- CQUI calculate real housing for the selected city
+  Controls.HousingTotalNum:SetText( data.Housing - data.HousingFromImprovements + CQUI_HousingFromImprovements );    -- CQUI calculate real housing
   Controls.HousingTotalNum:SetColorByName( colorName );
   local uv:number;
 
@@ -903,6 +905,14 @@ function OnShowBreakdownTab()
   m_tabs.SelectTab( Controls.BuildingsButton );
 end
 
+-- ===========================================================================
+--CQUI get real housing from improvements
+local CQUI_HousingFromImprovementsTable :table = {};
+function CQUI_HousingFromImprovementsTableInsert (pCityID, CQUI_HousingFromImprovements)
+  CQUI_HousingFromImprovementsTable[pCityID] = CQUI_HousingFromImprovements;
+end
+
+-- ===========================================================================
 function Initialize()
   PopulateTabs();
 
@@ -916,6 +926,7 @@ function Initialize()
   Events.SystemUpdateUI.Add( OnUpdateUI );
   LuaEvents.CityPanel_ShowOverviewPanel.Add( OnShowOverviewPanel );
   LuaEvents.CityPanel_LiveCityDataChanged.Add( OnLiveCityDataChanged )
+  LuaEvents.CQUI_RealHousingFromImprovementsCalculated.Add(CQUI_HousingFromImprovementsTableInsert);    --CQUI get real housing from improvements values
 
   Events.SystemUpdateUI.Add( OnUpdateUI );
   Events.CityNameChanged.Add(OnCityNameChanged);

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -3268,7 +3268,12 @@ function CQUI_RealHousingFromImprovements(pCity)
           if kImprovementData == 1 then    -- farms, pastures etc.
             CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 1;
           elseif kImprovementData == 2 then    -- stepwells
-            CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 2;
+            local CQUI_PlayerResearchedSanitation :boolean = Players[Game.GetLocalPlayer()]:GetTechs():HasTech(40);    -- check if a player researched Sanitation (Index == 40)
+            if not CQUI_PlayerResearchedSanitation then
+              CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 2;
+            else
+              CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 4;
+            end
           end
         end
       end

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -1045,28 +1045,30 @@ function CityBanner.UpdateStats( self : CityBanner)
         end
 
         if g_smartbanner and g_smartbanner_population then
-          self.m_Instance.CityPopulation:SetToolTipString(popTooltip);
-          local CQUI_HousingFromImprovements = CQUI_RealHousingFromImprovements(pCity);    -- CQUI calculate real housing from improvements
-          local housingLeft = pCityGrowth:GetHousing() - pCityGrowth:GetHousingFromImprovements() + CQUI_HousingFromImprovements - currentPopulation;    -- CQUI calculate real housing
-          local housingLeftText = housingLeft;
-          local housingLeftColor = "Error";
-          if housingLeft > 1.5 then
-            housingLeftColor = "StatGoodCS";
-            housingLeftText = "+"..housingLeft;
-            --COLOR: Green
-          elseif housingLeft <= 1.5 and housingLeft > 0.5 then
-            housingLeftColor = "WarningMinor";
-            housingLeftText = "+"..housingLeft;
-            --COLOR: Yellow
-					elseif housingLeft == 0.5 then
-            housingLeftColor = "WarningMajor";
-            housingLeftText = "+"..housingLeft;
-          elseif housingLeft < 0.5 and housingLeft >= -4.5 then
-            housingLeftColor = "WarningMajor";
+          if CQUI_RealHousingFromImprovements(pCity) ~= nil then    -- CQUI real housing from improvements fix when waiting for the next turn
+            self.m_Instance.CityPopulation:SetToolTipString(popTooltip);
+            local CQUI_HousingFromImprovements = CQUI_RealHousingFromImprovements(pCity);    -- CQUI calculate real housing from improvements
+            local housingLeft = pCityGrowth:GetHousing() - pCityGrowth:GetHousingFromImprovements() + CQUI_HousingFromImprovements - currentPopulation;    -- CQUI calculate real housing
+            local housingLeftText = housingLeft;
+            local housingLeftColor = "Error";
+            if housingLeft > 1.5 then
+              housingLeftColor = "StatGoodCS";
+              housingLeftText = "+"..housingLeft;
+              --COLOR: Green
+            elseif housingLeft <= 1.5 and housingLeft > 0.5 then
+              housingLeftColor = "WarningMinor";
+              housingLeftText = "+"..housingLeft;
+              --COLOR: Yellow
+					  elseif housingLeft == 0.5 then
+              housingLeftColor = "WarningMajor";
+              housingLeftText = "+"..housingLeft;
+            elseif housingLeft < 0.5 and housingLeft >= -4.5 then
+              housingLeftColor = "WarningMajor";
+            end
+            local CTLS = "[COLOR:"..popTurnLeftColor.."]"..turnsUntilGrowth.."[ENDCOLOR]  [[COLOR:"..housingLeftColor.."]"..housingLeftText.."[ENDCOLOR]]  ";
+            self.m_Instance.CityPopTurnsLeft:SetText(CTLS);
+            self.m_Instance.CityPopTurnsLeft:SetHide(false);
           end
-          local CTLS = "[COLOR:"..popTurnLeftColor.."]"..turnsUntilGrowth.."[ENDCOLOR]  [[COLOR:"..housingLeftColor.."]"..housingLeftText.."[ENDCOLOR]]  ";
-          self.m_Instance.CityPopTurnsLeft:SetText(CTLS);
-          self.m_Instance.CityPopTurnsLeft:SetHide(false);
         else
           self.m_Instance.CityPopTurnsLeft:SetHide(true);
         end

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -1045,9 +1045,9 @@ function CityBanner.UpdateStats( self : CityBanner)
         end
 
         if g_smartbanner and g_smartbanner_population then
-          if CQUI_RealHousingFromImprovements(pCity) ~= nil then    -- CQUI real housing from improvements fix when waiting for the next turn
-            self.m_Instance.CityPopulation:SetToolTipString(popTooltip);
-            local CQUI_HousingFromImprovements = CQUI_RealHousingFromImprovements(pCity);    -- CQUI calculate real housing from improvements
+          local CQUI_HousingFromImprovements = CQUI_RealHousingFromImprovements(pCity);    -- CQUI calculate real housing from improvements
+          if CQUI_HousingFromImprovements ~= nil then    -- CQUI real housing from improvements fix to show correct values when waiting for the next turn
+            self.m_Instance.CityPopulation:SetToolTipString(popTooltip);            
             local housingLeft = pCityGrowth:GetHousing() - pCityGrowth:GetHousingFromImprovements() + CQUI_HousingFromImprovements - currentPopulation;    -- CQUI calculate real housing
             local housingLeftText = housingLeft;
             local housingLeftColor = "Error";

--- a/Assets/UI/civ6common.lua
+++ b/Assets/UI/civ6common.lua
@@ -1043,7 +1043,9 @@ function CQUI_RealHousingFromImprovements(pCity)
         end
       end
     end
-  CQUI_HousingFromImprovements = CQUI_HousingFromImprovements * 0.5;
+    CQUI_HousingFromImprovements = CQUI_HousingFromImprovements * 0.5;
+  else
+    return;
   end
   return CQUI_HousingFromImprovements;
 end

--- a/Assets/UI/civ6common.lua
+++ b/Assets/UI/civ6common.lua
@@ -1021,31 +1021,3 @@ function PopulateSlider(control, label, setting_name, data_converter, tooltip)
     control:SetToolTipString(tooltip);
   end
 end
-
--- ===========================================================================
--- CQUI calculate real housing from improvements
-function CQUI_RealHousingFromImprovements(pCity)
-  local CQUI_HousingFromImprovements = 0;
-  local tParameters :table = {};
-  tParameters[CityCommandTypes.PARAM_MANAGE_CITIZEN] = UI.GetInterfaceModeParameter(CityCommandTypes.PARAM_MANAGE_CITIZEN);
-  local tResults :table = CityManager.GetCommandTargets( pCity, CityCommandTypes.MANAGE, tParameters );
-  local tPlots :table = tResults[CityCommandResults.PLOTS];
-  if tPlots ~= nil and (table.count(tPlots) > 0) then
-    for i, plotId in pairs(tPlots) do
-      local kPlot	:table = Map.GetPlotByIndex(plotId);
-      local eImprovementType :number = kPlot:GetImprovementType();
-      if( eImprovementType ~= -1 ) then
-        local kImprovementData = GameInfo.Improvements[eImprovementType].Housing;
-        if kImprovementData == 1 then    -- farms, pastures etc.
-          CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 1;
-        elseif kImprovementData == 2 then    -- stepwells
-          CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 2;
-        end
-      end
-    end
-    CQUI_HousingFromImprovements = CQUI_HousingFromImprovements * 0.5;
-  else
-    return;
-  end
-  return CQUI_HousingFromImprovements;
-end

--- a/Integrations/URS/reportscreen.lua
+++ b/Integrations/URS/reportscreen.lua
@@ -1492,7 +1492,9 @@ function city_fields( kCityData, pCityInstance )
 
 	pCityInstance.GrowthRateStatus:SetText( Locale.Lookup(status) );
 
-  local CQUI_HousingFromImprovements = CQUI_RealHousingFromImprovements(kCityData.City);    -- CQUI calculate real housing from improvements
+	-- CQUI get real housing from improvements value
+	local kCityID = kCityData.City:GetID();
+	local CQUI_HousingFromImprovements = CQUI_HousingFromImprovementsTable[kCityID];
 	pCityInstance.Housing:SetText( tostring( kCityData.Housing - kCityData.HousingFromImprovements + CQUI_HousingFromImprovements ) );    -- CQUI calculate real housing
 	pCityInstance.Amenities:SetText( tostring(kCityData.AmenitiesNum).." / "..tostring(kCityData.AmenitiesRequiredNum) );
 
@@ -2131,6 +2133,14 @@ function OnToggleBonus()
 end
 --ARISTOS: End resources toggle
 
+-- ===========================================================================
+--CQUI get real housing from improvements
+local CQUI_HousingFromImprovementsTable :table = {};
+function CQUI_HousingFromImprovementsTableInsert (pCityID, CQUI_HousingFromImprovements)
+  CQUI_HousingFromImprovementsTable[pCityID] = CQUI_HousingFromImprovements;
+end
+
+-- ===========================================================================
 function Initialize()
 
 	Resize();
@@ -2179,6 +2189,7 @@ function Initialize()
 	-- Events
 	LuaEvents.TopPanel_OpenReportsScreen.Add( OnTopOpenReportsScreen );
 	LuaEvents.TopPanel_CloseReportsScreen.Add( OnTopCloseReportsScreen );
+  LuaEvents.CQUI_RealHousingFromImprovementsCalculated.Add(CQUI_HousingFromImprovementsTableInsert);    --CQUI get real housing from improvements values
 end
 Initialize();
 

--- a/Integrations/URS/reportscreen.lua
+++ b/Integrations/URS/reportscreen.lua
@@ -2189,7 +2189,7 @@ function Initialize()
 	-- Events
 	LuaEvents.TopPanel_OpenReportsScreen.Add( OnTopOpenReportsScreen );
 	LuaEvents.TopPanel_CloseReportsScreen.Add( OnTopCloseReportsScreen );
-  LuaEvents.CQUI_RealHousingFromImprovementsCalculated.Add(CQUI_HousingFromImprovementsTableInsert);    --CQUI get real housing from improvements values
+	LuaEvents.CQUI_RealHousingFromImprovementsCalculated.Add(CQUI_HousingFromImprovementsTableInsert);    --CQUI get real housing from improvements values
 end
 Initialize();
 

--- a/Integrations/URS/reportscreen.lua
+++ b/Integrations/URS/reportscreen.lua
@@ -88,6 +88,8 @@ local m_kCurrentDeals	:table = nil;
 local m_kCurrentTab = 1
 -- !!
 
+local CQUI_HousingFromImprovementsTable :table = {};
+
 -- ===========================================================================
 --	Single exit point for display
 -- ===========================================================================
@@ -2135,7 +2137,6 @@ end
 
 -- ===========================================================================
 --CQUI get real housing from improvements
-local CQUI_HousingFromImprovementsTable :table = {};
 function CQUI_HousingFromImprovementsTableInsert (pCityID, CQUI_HousingFromImprovements)
   CQUI_HousingFromImprovementsTable[pCityID] = CQUI_HousingFromImprovements;
 end


### PR DESCRIPTION
Fixes issue when the game shows wrong "real housing" values sometimes on citybanners when waiting for the next turn or for a short period of time when load an autosaved game. Now we can always see correct values on citybanners. When load an autosaved game it doesn't show growth info at all for a short period of time instead of showing wrong values.
City panel text is now lowercase to fit info fields including housing capacity info when it contains two-digit fractional numbers (10/10.5 for example).

Update: all 5 affected files reworked. Now we don't calculate values for the second time when open cityview or reportscreen as soon as it's already done for citybanner and we get these values via lua.events.