### PR TITLE
Update all cities data when swap tiles - fix

### DIFF
--- a/Assets/UI/WorldView/plotinfo.lua
+++ b/Assets/UI/WorldView/plotinfo.lua
@@ -78,6 +78,7 @@ function OnClickSwapTile( plotId:number )
 
   local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.SWAP_TILE_OWNER, tParameters );
   
+  OnClickCitizen();    -- CQUI update selected city citizens and data
   CQUI_UpdateAllCitiesCitizens();    -- CQUI update all cities citizens and data when swap tiles
   return true;
 end


### PR DESCRIPTION
Fixes an issue when production panel's data doesn't update when swap tiles. It's because of this commit 1c6a6940ed00ce2ee3347e1a4c563066d8038325 in #535. Here we restore this line back.