### PR TITLE
Naturalist Lens

### DIFF
--- a/Integrations/ML/Text/morelenses_text.xml
+++ b/Integrations/ML/Text/morelenses_text.xml
@@ -131,7 +131,10 @@
       <Text>Naturalist</Text>
     </Row>
     <Row Tag="LOC_HUD_NATURALIST_LENS_TOOLTIP">
-      <Text>Highlights what hexes are suitable for National Parks</Text>
+      <Text>Highlights places where National Parks can be built</Text>
+    </Row>
+    <Row Tag="LOC_TOOLTIP_NATURALIST_LENS_NPARK">
+      <Text>Area is ok for National Park</Text>
     </Row>
     <Row Tag="LOC_TOOLTIP_NATURALIST_LENS_OK">
       <Text>Tile is ok for National Park</Text>

--- a/Integrations/ML/Text/morelenses_text.xml
+++ b/Integrations/ML/Text/morelenses_text.xml
@@ -126,5 +126,19 @@
       <Text>Goody Hut</Text>
     </Row>
 
+    <!-- Naturalist Lens -->
+    <Row Tag="LOC_HUD_NATURALIST_LENS">
+      <Text>Naturalist</Text>
+    </Row>
+    <Row Tag="LOC_HUD_NATURALIST_LENS_TOOLTIP">
+      <Text>Highlights what hexes are suitable for National Parks</Text>
+    </Row>
+    <Row Tag="LOC_TOOLTIP_NATURALIST_LENS_OK">
+      <Text>Tile is ok for National Park</Text>
+    </Row>
+    <Row Tag="LOC_TOOLTIP_NATURALIST_LENS_FIXABLE">
+      <Text>Tile is ok, but something fixable is blocking</Text>
+    </Row>
+
   </BaseGameText>
 </GameData>

--- a/Integrations/ML/UI/Panels/modallenspanel.lua
+++ b/Integrations/ML/UI/Panels/modallenspanel.lua
@@ -296,8 +296,9 @@ end
 function ShowNaturalistLensKey()
 	m_KeyStackIM: ResetInstances();
 
+	local parkNaturalistLens     :number = UI.GetColorValue("COLOR_PARK_NATURALIST_LENS");
+	AddKeyEntry("LOC_TOOLTIP_NATURALIST_LENS_NPARK", parkNaturalistLens);
 	AddKeyEntry("LOC_TOOLTIP_NATURALIST_LENS_OK", UI.GetColorValue("COLOR_OK_NATURALIST_LENS"));
-
 	AddKeyEntry("LOC_TOOLTIP_NATURALIST_LENS_FIXABLE", UI.GetColorValue("COLOR_FIXABLE_NATURALIST_LENS"));
 
 	Controls.KeyPanel:SetHide(false);

--- a/Integrations/ML/UI/Panels/modallenspanel.lua
+++ b/Integrations/ML/UI/Panels/modallenspanel.lua
@@ -20,6 +20,7 @@ local MODDED_LENS_ID:table = {
 	WONDER 			= 8;
 	ADJACENCY_YIELD = 9;
 	SCOUT 			= 10;
+	NATURALIST		= 11;
 };
 
 --============================================================================
@@ -292,6 +293,18 @@ function ShowScoutLensKey()
 end
 
 --============================================================================
+function ShowNaturalistLensKey()
+	m_KeyStackIM: ResetInstances();
+
+	AddKeyEntry("LOC_TOOLTIP_NATURALIST_LENS_OK", UI.GetColorValue("COLOR_OK_NATURALIST_LENS"));
+
+	AddKeyEntry("LOC_TOOLTIP_NATURALIST_LENS_FIXABLE", UI.GetColorValue("COLOR_FIXABLE_NATURALIST_LENS"));
+
+	Controls.KeyPanel:SetHide(false);
+	Controls.KeyScrollPanel:CalculateSize();
+end
+
+--============================================================================
 function OnAddContinentColorPair( pContinentColors:table )
 	m_ContinentColorList = pContinentColors;
 end
@@ -445,6 +458,9 @@ function OnLensLayerOn( layerNum:number )
 		elseif GetCurrentModdedLens() == MODDED_LENS_ID.SCOUT then
 			Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_SCOUT_LENS")));
 			ShowScoutLensKey();
+		elseif GetCurrentModdedLens() == MODDED_LENS_ID.NATURALIST then
+			Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_NATURALIST_LENS")));
+			ShowNaturalistLensKey();
 		end
 	elseif layerNum == LensLayers.HEX_COLORING_GOVERNMENT then
 		Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_GOVERNMENT_LENS")));

--- a/Integrations/ML/UI/minimappanel.lua
+++ b/Integrations/ML/UI/minimappanel.lua
@@ -1441,15 +1441,14 @@ end
 
 -- ===========================================================================
 function SetNaturalistLens()
-  -- Check required to work properly with hotkey.
-  -- print("Highlight Naturalist Lens Hexes");
-  local mapWidth, mapHeight = Map.GetGridSize();
-
+  --print("Show Naturalist lens")
+  local localPlayer:number = Game.GetLocalPlayer();
+  local parkPlotColor:number = UI.GetColorValue("COLOR_PARK_NATURALIST_LENS");
   local OkColor:number = UI.GetColorValue("COLOR_OK_NATURALIST_LENS");
   local FixableColor:number = UI.GetColorValue("COLOR_FIXABLE_NATURALIST_LENS");
-  local localPlayer:number = Game.GetLocalPlayer();
+  local rawParkPlots:table = Game.GetNationalParks():GetPossibleParkTiles(localPlayer);
   local localPlayerVis:table = PlayersVisibility[localPlayer];
-
+  local mapWidth, mapHeight = Map.GetGridSize();
   local fixableHexes:table = {};
   local okHexes:table = {};
 
@@ -1500,6 +1499,9 @@ function SetNaturalistLens()
   end
   if table.count(okHexes) > 0 then
     UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_APPEAL_LEVEL, localPlayer, okHexes, OkColor );
+  end
+  if table.count(rawParkPlots) > 0 then
+    UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_APPEAL_LEVEL, localPlayer, rawParkPlots, parkPlotColor );
   end
 end
 

--- a/Integrations/ML/UI/minimappanel.xml
+++ b/Integrations/ML/UI/minimappanel.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Context>
 
   <SlideAnim  Size="parent,parent"  ID="Pause" Begin="0,0" End="0,160" Function="Root" Speed="4"    Cycle="Once"  Stopped="1"/>
@@ -23,6 +23,7 @@
         <RadioButton  ID="WonderLensButton"   RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_WONDER_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_WONDER_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
         <RadioButton  ID="AdjacencyYieldLensButton"   RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_ADJYIELD_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_ADJYIELD_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
         <RadioButton  ID="ScoutLensButton"    RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_SCOUT_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_SCOUT_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
+        <RadioButton  ID="NaturalistLensButton"    RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_NATURALIST_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_NATURALIST_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
       </Stack>
     </ScrollPanel>
     <Image Texture="Controls_ButtonExtendSmall" TextureOffset="0,60" Size="20,20" Anchor="L,B" Offset="22,10"/>

--- a/Integrations/ML/morelenses_colors.sql
+++ b/Integrations/ML/morelenses_colors.sql
@@ -69,7 +69,9 @@ VALUES                  (   'COLOR_GHUT_SCOUT_LENS',            '0.56',     '0.0
 
 -- Naturalist Lens
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_OK_NATURALIST_LENS',         '0',        '1',        '0',        '0.5');
+VALUES                  (   'COLOR_PARK_NATURALIST_LENS',       '0',        '1',        '0',        '0.5');
+INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_OK_NATURALIST_LENS',         '0',        '1',        '1',        '0.5');
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
 VALUES                  (   'COLOR_FIXABLE_NATURALIST_LENS',    '0.56',     '0.0',      '0.98',     '0.5');
 

--- a/Integrations/ML/morelenses_colors.sql
+++ b/Integrations/ML/morelenses_colors.sql
@@ -66,3 +66,10 @@ VALUES                  (   'COLOR_PLAYER_WONDER_LENS',         '0.98',     '0.0
 
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
 VALUES                  (   'COLOR_GHUT_SCOUT_LENS',            '0.56',     '0.0',      '0.98',     '0.5');
+
+-- Naturalist Lens
+INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_OK_NATURALIST_LENS',         '0',        '1',        '0',        '0.5');
+INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_FIXABLE_NATURALIST_LENS',    '0.56',     '0.0',      '0.98',     '0.5');
+


### PR DESCRIPTION
This adds a Naturalist Lens to help localise where National Parks can be built.
It extends the Naturalist from MoreLenses by highlighting potential tiles that
could become a Park except for something simple such as removing an
improvement or change ownership.
