### PR TITLE
Forces lenses settings at start of game

### DIFF
--- a/Integrations/ML/UI/minimappanel.lua
+++ b/Integrations/ML/UI/minimappanel.lua
@@ -2462,7 +2462,6 @@ end
 -- INITIALIZATION
 -- ===========================================================================
 function Initialize()
-	CQUI_OnSettingsUpdate(); --ARISTOS: to force lenses settings when first starting the game
   m_MiniMap_xmloffsety = Controls.MiniMap:GetOffsetY();
   m_ContinentsCache = Map.GetContinentsInUse();
   UI.SetMinimapImageControl(Controls.MinimapImage);
@@ -2553,5 +2552,6 @@ function Initialize()
   LuaEvents.CQUI_SettingsUpdate.Add( CQUI_OnSettingsUpdate );
   LuaEvents.CQUI_SettingsInitialized.Add( CQUI_UpdateMinimapSize );
   LuaEvents.CQUI_SettingsInitialized.Add( CQUI_ToggleYieldIcons );
+  CQUI_OnSettingsUpdate(); --ARISTOS: to force lenses settings when first starting the game
 end
 Initialize();

--- a/Integrations/ML/UI/minimappanel.lua
+++ b/Integrations/ML/UI/minimappanel.lua
@@ -2462,6 +2462,7 @@ end
 -- INITIALIZATION
 -- ===========================================================================
 function Initialize()
+	CQUI_OnSettingsUpdate(); --ARISTOS: to force lenses settings when first starting the game
   m_MiniMap_xmloffsety = Controls.MiniMap:GetOffsetY();
   m_ContinentsCache = Map.GetContinentsInUse();
   UI.SetMinimapImageControl(Controls.MinimapImage);


### PR DESCRIPTION
There was a small bug that bugged me, no pun intended, since forever. Builder lenses settings were never enforced at the very start when I had them to zero in settings. Same probably happened to scout and archeos, but I never tried.
This small fix should take care of it once and for all.