### PR TITLE
Update production panel's data - fix, Update data when swap tiles - fix

### DIFF
--- a/Assets/UI/Panels/citypanel.lua
+++ b/Assets/UI/Panels/citypanel.lua
@@ -809,7 +809,7 @@ function RefreshOnTurnRoll()
 
     end
 
-    tParameters[CityCommandTypes.PARAM_YIELD_TYPE]= yieldType;  -- Yield type
+    tParameters[CityCommandTypes.PARAM_YIELD_TYPE] = YieldTypes.CULTURE;  -- Yield type
     CityManager.RequestCommand(m_pCity, CityCommandTypes.SET_FOCUS, tParameters);
 
     m_kData = GetCityData( m_pCity );
@@ -872,7 +872,7 @@ function OnTileImproved(x, y)
         tParameters[CityCommandTypes.PARAM_DATA0] = 0;          -- off
       end
       
-      tParameters[CityCommandTypes.PARAM_YIELD_TYPE]= yieldType;  -- Yield type
+      tParameters[CityCommandTypes.PARAM_YIELD_TYPE] = YieldTypes.CULTURE;  -- Yield type
       CityManager.RequestCommand(m_pCity, CityCommandTypes.SET_FOCUS, tParameters);
 
       m_kData = GetCityData( m_pCity );

--- a/Assets/UI/Panels/citypanel.lua
+++ b/Assets/UI/Panels/citypanel.lua
@@ -1105,7 +1105,6 @@ function OnCheckYield( yieldType:number, yieldName:string )
     Controls[yieldName.."Ignore"]:SetHide( false );
     Controls[yieldName.."Check"]:SetDisabled( true );
   end
-  CQUI_UpdateSelectedCityCitizens();    -- CQUI Update production panel's data when changing yield focus
 end
 
 -- ===========================================================================
@@ -1118,7 +1117,6 @@ function OnResetYieldToNormal( yieldType:number, yieldName:string )
   Controls[yieldName.."Ignore"]:SetHide( true );
   Controls[yieldName.."Check"]:SetDisabled( false );
   SetYieldIgnore( yieldType );    -- One more ignore to flip it off
-  CQUI_UpdateSelectedCityCitizens();    -- CQUI Update production panel's data when changing yield focus
 end
 
 -- ===========================================================================

--- a/Assets/UI/Panels/productionpanel.lua
+++ b/Assets/UI/Panels/productionpanel.lua
@@ -2693,7 +2693,7 @@ function OnCityProductionCompleted(playerID, cityID, orderType, unitType, cancel
   if (pCity == nil) then return end;
 
   local currentTurn = Game.GetCurrentGameTurn();
-  
+
   local productionQueueTableKey = FindProductionQueueKey(cityID, pCity:GetOwner())
 
   -- Only one item can be produced per turn per city
@@ -2801,7 +2801,7 @@ end
 
 --- ==========================================================================
 --  Finds production queue key based on player and current city id
---  Desirable improvement : Refactor to use local player ID as a key to the table of cities instead 
+--  Desirable improvement : Refactor to use local player ID as a key to the table of cities instead
 --                          of mixing all cities in one queue.
 --                          At the moment only allow 1000 cities per active local player.
 --- ==========================================================================
@@ -2832,7 +2832,7 @@ function LoadQueues()
     local currentProductionHash = buildQueue:GetCurrentProductionTypeHash();
     local plotID = -1;
 	local productionQueueTableKey = FindProductionQueueKey(cityID, city:GetOwner());
-	
+
     if(not prodQueue[productionQueueTableKey]) then
       prodQueue[productionQueueTableKey] = {};
     end
@@ -3329,7 +3329,7 @@ end
 function BuildFirstQueued(pCity)
   local cityID = pCity:GetID();
   local productionQueueTableKey = FindProductionQueueKey(cityID, pCity:GetOwner())
-  
+
   if(prodQueue[productionQueueTableKey][1]) then
     if(prodQueue[productionQueueTableKey][1].type == PRODUCTION_TYPE.BUILDING) then
       BuildBuilding(pCity, prodQueue[productionQueueTableKey][1].entry);
@@ -3722,7 +3722,7 @@ function ResetCityQueue(cityID, player)
   end
   if(not player) then return end
   local city = player:GetCities():FindID(cityID);
-  
+
   if(not city) then return end
 
   local buildQueue = city:GetBuildQueue();

--- a/Assets/UI/Panels/productionpanel.lua
+++ b/Assets/UI/Panels/productionpanel.lua
@@ -3864,7 +3864,9 @@ function Initialize()
   Events.CityProductionCompleted.Add(OnCityProductionCompleted);
   Events.CityProductionUpdated.Add(OnCityProductionUpdated);
 
+  -- CQUI Update production panel
   Events.CityWorkerChanged.Add(Refresh);
+  Events.CityFocusChanged.Add(Refresh);
 
   -- CQUI Setting Controls
   PopulateCheckBox(Controls.CQUI_ProductionQueueCheckbox, "CQUI_ProductionQueue");

--- a/Assets/UI/WorldView/plotinfo.lua
+++ b/Assets/UI/WorldView/plotinfo.lua
@@ -977,7 +977,7 @@ function CQUI_UpdateAllCitiesCitizens()
       tParameters[CityCommandTypes.PARAM_DATA0] = 0;          -- off
     end
     
-    tParameters[CityCommandTypes.PARAM_YIELD_TYPE]= yieldType;  -- Yield type
+    tParameters[CityCommandTypes.PARAM_YIELD_TYPE] = YieldTypes.CULTURE;  -- Yield type
     CityManager.RequestCommand(pCity, CityCommandTypes.SET_FOCUS, tParameters);
   end
 end

--- a/Assets/UI/WorldView/plotinfo.lua
+++ b/Assets/UI/WorldView/plotinfo.lua
@@ -78,7 +78,6 @@ function OnClickSwapTile( plotId:number )
 
   local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.SWAP_TILE_OWNER, tParameters );
   
-  OnClickCitizen();    -- CQUI update selected city citizens and data
   CQUI_UpdateAllCitiesCitizens();    -- CQUI update all cities citizens and data when swap tiles
   return true;
 end


### PR DESCRIPTION
Removed unnecessary lines when swap tiles and when change city yield focus  as soon as production panel updates now with `Events.CityFocusChanged`.
Fixed `CQUI_UpdateAllCitiesCitizens` function to not to use incorrect variable that caused crash sometimes when try to quickload a game right after swap tiles. And also fixed `OnTileImproved` and `RefreshOnTurnRoll` functions to not to use incorrect variable.
This PR is related to 562368fcba1991e6e64fcee78a0bfa1e24a1bb0d #527 #535 #558 