### PR TITLE
Remove corps/army production recommendations

### DIFF
--- a/Assets/UI/Panels/productionpanel.lua
+++ b/Assets/UI/Panels/productionpanel.lua
@@ -608,7 +608,7 @@ function PopulateList(data, listIM)
       end
       ResetInstanceVisibility(unitListing);
       unitListing.ButtonContainer:SetSizeY(CQUI_INSTANCE_Y);
-      -- Check to see if this item is recommended
+      -- Check to see if this item is recommended           -- CQUI: Remove production recommendations
       --for _,hash in ipairs( m_recommendedItems) do
       --  if(item.Hash == hash.BuildItemHash) then
       --    unitListing.RecommendedIcon:SetHide(false);
@@ -825,12 +825,12 @@ function PopulateList(data, listIM)
       end
 
       if item.Corps then
-        -- Check to see if this item is recommended
-        for _,hash in ipairs( m_recommendedItems) do
-          if(item.Hash == hash.BuildItemHash) then
-            unitListing.CorpsRecommendedIcon:SetHide(false);
-          end
-        end
+        -- Check to see if this item is recommended           -- CQUI: Remove production recommendations
+        --for _,hash in ipairs( m_recommendedItems) do
+          --if(item.Hash == hash.BuildItemHash) then
+            --unitListing.CorpsRecommendedIcon:SetHide(false);
+          --end
+        --end
         unitListing.CorpsButtonContainer:SetHide(false);
         -- Production meter progress for corps unit
 
@@ -901,12 +901,12 @@ function PopulateList(data, listIM)
         end);
       end
       if item.Army then
-        -- Check to see if this item is recommended
-        for _,hash in ipairs( m_recommendedItems) do
-          if(item.Hash == hash.BuildItemHash) then
-            unitListing.ArmyRecommendedIcon:SetHide(false);
-          end
-        end
+        -- Check to see if this item is recommended           -- CQUI: Remove production recommendations
+        --for _,hash in ipairs( m_recommendedItems) do
+          --if(item.Hash == hash.BuildItemHash) then
+            --unitListing.ArmyRecommendedIcon:SetHide(false);
+          --end
+        --end
         unitListing.ArmyButtonContainer:SetHide(false);
 
         -- ProductionQueue: We need to check that there isn't already one of these in the queue
@@ -1095,7 +1095,7 @@ function PopulateList(data, listIM)
       districtListing.ButtonContainer:SetSizeY(CQUI_INSTANCE_Y);
       districtListing.BuildingDrawer:SetOffsetY(CQUI_INSTANCE_Y);
       ResetInstanceVisibility(districtListing);
-      -- Check to see if this district item is one of the items that is recommended:
+      -- Check to see if this district item is one of the items that is recommended:      -- CQUI: Remove production recommendations
       --for _,hash in ipairs( m_recommendedItems) do
       --  if(item.Hash == hash.BuildItemHash) then
       --    districtListing.RecommendedIcon:SetHide(false);
@@ -1117,7 +1117,7 @@ function PopulateList(data, listIM)
       if(item.HasBeenBuilt and GameInfo.Districts[item.Type].OnePerCity == true and not item.Repair and not item.Contaminated) then
         turnsStrTT = Locale.Lookup("LOC_HUD_CITY_DISTRICT_BUILT_TT");
         turnsStr = "[ICON_Checkmark]";
-        districtListing.RecommendedIcon:SetHide(true);
+        --districtListing.RecommendedIcon:SetHide(true);            -- CQUI: Remove production recommendations
       else
         if(item.TurnsLeft) then
           turnsStrTT = item.TurnsLeft .. Locale.Lookup("LOC_HUD_CITY_TURNS_TO_COMPLETE", item.TurnsLeft);
@@ -1259,7 +1259,7 @@ function PopulateList(data, listIM)
             CQUI_ProdTable[buildingItem.Hash] = {};
           end
           CQUI_ProdTable[buildingItem.Hash]["time"] = buildingItem.TurnsLeft;
-          -- Check to see if this is one of the recommended items
+          -- Check to see if this is one of the recommended items           -- CQUI: Remove production recommendations
           --for _,hash in ipairs( m_recommendedItems) do
           --  if(buildingItem.Hash == hash.BuildItemHash) then
           --    buildingListing.RecommendedIcon:SetHide(false);
@@ -1383,7 +1383,7 @@ function PopulateList(data, listIM)
         wonderListing.Button:SetSizeY(CQUI_INSTANCE_Y);
         wonderListing.PurchaseButton:SetHide(true);
         wonderListing.FaithPurchaseButton:SetHide(true);
-        --for _,hash in ipairs( m_recommendedItems) do
+        --for _,hash in ipairs( m_recommendedItems) do            -- CQUI: Remove production recommendations
         --  if(item.Hash == hash.BuildItemHash) then
         --    wonderListing.RecommendedIcon:SetHide(false);
         --  end
@@ -1470,7 +1470,7 @@ function PopulateList(data, listIM)
     for i, item in ipairs(data.ProjectItems) do
       local projectListing = projectList.projectListIM:GetInstance();
       ResetInstanceVisibility(projectListing);
-      -- Check to see if this item is recommended
+      -- Check to see if this item is recommended           -- CQUI: Remove production recommendations
       --for _,hash in ipairs( m_recommendedItems) do
       --  if(item.Hash == hash.BuildItemHash) then
       --    projectListing.RecommendedIcon:SetHide(false);


### PR DESCRIPTION
This PR removes recommendations for corps/army production. It is related to 408f406f8abe2a38686cf73b0b1e8461bfd453ab and 15fa14f79bbfaec1ebed85638f5701a35bc4dd44. CQUI comments also added to simplify future files comparison.