### PR TITLE
Fix for InlandSea crash

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ indent_style = space
 indent_size = 2
 end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = false
+trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.md]

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ indent_style = space
 indent_size = 2
 end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = true
+trim_trailing_whitespace = false
 insert_final_newline = true
 
 [*.md]

--- a/Assets/UI/Panels/citypanel.lua
+++ b/Assets/UI/Panels/citypanel.lua
@@ -238,10 +238,10 @@ function CQUI_ToggleGrowthTile()
 end
 function CQUI_SettingsUpdate()
   CQUI_growthTile = GameConfiguration.GetValue("CQUI_ShowCultureGrowth");
-  if(CQUI_growthTile) then
+  if(m_GrowthPlot ~= -1 and not CQUI_growthTile) then
+    UILens.ClearHex(LensLayers.PURCHASE_PLOT, m_GrowthPlot);
     m_GrowthPlot = -1;
   end
-  UILens.ClearHex(LensLayers.PURCHASE_PLOT, m_GrowthPlot);
   if(UI.GetInterfaceMode() == InterfaceModeTypes.CITY_MANAGEMENT) then
     DisplayGrowthTile();
   end


### PR DESCRIPTION
Fixes #512

It seems that calling ClearHex with -1 for plot is causing a crash toghether with InlandSeas GetMapInitData, so lets not call it with -1.

I have done some tests and I don't crash when changing settings anymore.

Also setting trim_trailing_whitespace to false in .editorconfig to
prevent messy compares.