### PR TITLE
Issue #526 - Korean rendering bug

### DIFF
--- a/Assets/UI/ToolTips/plottooltip.lua
+++ b/Assets/UI/ToolTips/plottooltip.lua
@@ -368,7 +368,7 @@ function View(data:table, bIsUpdate:boolean)
 
   -- Defense modifier
   if (data.DefenseModifier ~= 0) then
-    table.insert(details, Locale.Lookup("LOC_TOOLTIP_DEFENSE_MODIFIER", data.DefenseModifier).. " [ICON_STRENGTH]");
+    table.insert(details, Locale.Lookup("LOC_TOOLTIP_DEFENSE_MODIFIER", data.DefenseModifier).. "[ICON_STRENGTH]");
   end
 
   -- Appeal

--- a/Assets/UI/ToolTips/plottooltip.lua
+++ b/Assets/UI/ToolTips/plottooltip.lua
@@ -356,7 +356,7 @@ function View(data:table, bIsUpdate:boolean)
       else
         szMoveString = Locale.Lookup("LOC_TOOLTIP_ROUTE_MOVEMENT", routeInfo.MovementCost, routeInfo.Name);
       end
-      szMoveString = szMoveString:gsub("%d?%.?%d+%s",routeInfo.MovementCost.. "[ICON_Movement]",1);
+      szMoveString = szMoveString.. "[ICON_Movement]";
     end
   elseif (not data.Impassable and data.MovementCost > 0) then
     szMoveString = Locale.Lookup("LOC_TOOLTIP_MOVEMENT_COST", data.MovementCost).. "[ICON_Movement]";

--- a/Assets/UI/ToolTips/plottooltip.lua
+++ b/Assets/UI/ToolTips/plottooltip.lua
@@ -359,8 +359,7 @@ function View(data:table, bIsUpdate:boolean)
       szMoveString = szMoveString:gsub("%d?%.?%d+%s",routeInfo.MovementCost.. "[ICON_Movement]",1);
     end
   elseif (not data.Impassable and data.MovementCost > 0) then
-    szMoveString = Locale.Lookup("LOC_TOOLTIP_MOVEMENT_COST", data.MovementCost);
-    szMoveString = szMoveString:gsub("%d?%.?%d+",data.MovementCost.. "[ICON_Movement]",1);
+    szMoveString = Locale.Lookup("LOC_TOOLTIP_MOVEMENT_COST", data.MovementCost).. "[ICON_Movement]";
   end
   if (szMoveString ~=nil) then
     --szMoveString = szMoveString:gsub("%d+%s",": [ICON_Movement]",1);


### PR DESCRIPTION
The source of this problem is the string pattern to identify where the icon needs to be inserted. From my tinkering, it seems one of the Korean characters, specifically '비', within `LOC_TOOLTIP_MOVEMENT_COST` is interpreted as a digit (`%d`) by Lua. This caused the replacement to occur in the wrong place, altering the character and causing the display error.

I tested in all languages to ensure this change does not break the implementation for other languages. The results of my testing shows that all languages supported by the base game are displayed in the following format: `%.*:%s%d` or "<movement translation>: <value>". This consistency in the supported languages allowed for the simplification of the `gsub` call within the route logic.