### PR TITLE
More Lenses for Summer 2017 Patch

### DIFF
--- a/Assets/Text/cqui_text_settings.xml
+++ b/Assets/Text/cqui_text_settings.xml
@@ -48,6 +48,24 @@
     <Row Tag="LOC_CQUI_CITYVIEW_SHOWYIELDSONCITYHOVER_TOOLTIP" Language="en_US">
       <Text>Shows citizen managament icons, tile yields, and border growth on hover</Text>
     </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITIZENICONSONHOVER" Language="en_US">
+      <Text>Show citizen icons on hover</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITIZENICONSONHOVER_TOOLTIP" Language="en_US">
+      <Text>Shows citizen icons when hovering over the city banner</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEONHOVER" Language="en_US">
+      <Text>Show city management area on hover</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEONHOVER_TOOLTIP" Language="en_US">
+      <Text>Shows citizen managament area when hovering over city banner</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEINSCREEN" Language="en_US">
+      <Text>Show city management area in screen</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEINSCREEN_TOOLTIP" Language="en_US">
+      <Text>Shows citizen managament area when in city screen</Text>
+    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_SMARTBANNER_HEADER" Language="en_US">
       <Text>Smartbanners</Text>
     </Row>
@@ -137,6 +155,12 @@
     </Row>
     <Row Tag="LOC_CQUI_LENSES_AUTOAPPLYSCOUTLENS" Language="en_US">
       <Text>Autoapply scout lens</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_LENSES_SHOWNOTHINGTODO" Language="en_US">
+      <Text>Show nothing to do in builder lens</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_LENSES_SHOWNOTHINGTODO_TOOLTIP" Language="en_US">
+      <Text>Shows nothing to do hexes (red tiles) when in builder lens</Text>
     </Row>
     <Row Tag="LOC_CQUI_POPUPS" Language="en_US">
       <Text>Popups</Text>

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -161,6 +161,9 @@ local ZOFFSET_3DVIEW        :number = 36;
 local SIZEOFPOPANDPROD        :number = 80; --The amount to add to the city banner to account for the size of the production icon and population number
 local SIZEOFPOPANDPRODMETERS    :number = 15; --The amount to add to the city banner backing width to allow for the production and population meters to appear
 
+local CQUI_ShowCitizenIconsOnCityHover:boolean = false;
+local CQUI_ShowCityManageAreaOnCityHover:boolean = true;
+
 -- ===========================================================================
 --  QUI
 -- ===========================================================================
@@ -185,6 +188,9 @@ function CQUI_OnSettingsInitialized()
   CQUI_SmartWorkIcon = GameConfiguration.GetValue("CQUI_SmartWorkIcon");
   CQUI_SmartWorkIconSize = GameConfiguration.GetValue("CQUI_SmartWorkIconSize");
   CQUI_SmartWorkIconAlpha = GameConfiguration.GetValue("CQUI_SmartWorkIconAlpha") / 100;
+
+  CQUI_ShowCitizenIconsOnCityHover = GameConfiguration.GetValue("CQUI_ShowCitizenIconsOnCityHover");
+  CQUI_ShowCityManageAreaOnCityHover = GameConfiguration.GetValue("CQUI_ShowCityManageAreaOnCityHover");
 end
 
 function CQUI_OnSettingsUpdate()
@@ -262,6 +268,10 @@ function CQUI_OnBannerMouseOver(playerID: number, cityID: number)
 
     CQUI_Hovering = true;
 
+    if CQUI_ShowCityManageAreaOnCityHover and not UILens.IsLayerOn(LensLayers.CITIZEN_MANAGEMENT) then
+      LuaEvents.Area_ShowCitizenManagement(cityID);
+    end
+
     local kPlayer = Players[playerID];
     local kCities = kPlayer:GetCities();
     local kCity = kCities:FindID(cityID);
@@ -289,7 +299,7 @@ function CQUI_OnBannerMouseOver(playerID: number, cityID: number)
     local yields :table = {};
     local yieldsIndex :table = {};
 
-    if (tPlots ~= nil and table.count(tPlots) ~= 0) and UILens.IsLayerOn(LensLayers.CITIZEN_MANAGEMENT) == false then
+    if CQUI_ShowCitizenIconsOnCityHover and (tPlots ~= nil and table.count(tPlots) ~= 0) and UILens.IsLayerOn(LensLayers.CITIZEN_MANAGEMENT) == false then
 
       CQUI_yieldsOn = UserConfiguration.ShowMapYield();
 
@@ -316,6 +326,11 @@ function CQUI_OnBannerMouseOver(playerID: number, cityID: number)
 
         if(tLockedUnits[i] > 0) then
           pInstance.LockedIcon:SetHide(false);
+          if(CQUI_SmartWorkIcon) then
+            pInstance.LockedIcon:SetAlpha(CQUI_SmartWorkIconAlpha);
+          else
+            pInstance.LockedIcon:SetAlpha(CQUI_WorkIconAlpha);
+          end
         else
           pInstance.LockedIcon:SetHide(true);
         end
@@ -404,9 +419,13 @@ function CQUI_OnBannerMouseExit(playerID: number, cityID: number)
     return;
   end
 
+  if CQUI_ShowCityManageAreaOnCityHover and not UILens.IsLayerOn(LensLayers.CITIZEN_MANAGEMENT) then
+    LuaEvents.Area_ClearCitizenManagement();
+  end
+
   local tPlots    :table = tResults[CityCommandResults.PLOTS];
 
-  if (tPlots ~= nil and table.count(tPlots) ~= 0) then
+  if CQUI_ShowCitizenIconsOnCityHover and (tPlots ~= nil and table.count(tPlots) ~= 0) then
 
     for i,plotId in pairs(tPlots) do
       local kPlot :table = Map.GetPlotByIndex(plotId);

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -299,7 +299,7 @@ function CQUI_OnBannerMouseOver(playerID: number, cityID: number)
     local yields :table = {};
     local yieldsIndex :table = {};
 
-    if CQUI_ShowCitizenIconsOnCityHover and (tPlots ~= nil and table.count(tPlots) ~= 0) and UILens.IsLayerOn(LensLayers.CITIZEN_MANAGEMENT) == false then
+    if (tPlots ~= nil and table.count(tPlots) ~= 0) and UILens.IsLayerOn(LensLayers.CITIZEN_MANAGEMENT) == false then
 
       CQUI_yieldsOn = UserConfiguration.ShowMapYield();
 
@@ -311,28 +311,30 @@ function CQUI_OnBannerMouseOver(playerID: number, cityID: number)
         local numUnits:number = tUnits[i];
         local maxUnits:number = tMaxUnits[i];
 
-        -- If this plot is getting worked
-        if workerCount > 0 and kPlot:IsCity() == false then
-          pInstance.CitizenButton:SetHide(false);
-          pInstance.CitizenButton:SetTextureOffsetVal(0, 256);
-          if(CQUI_SmartWorkIcon) then
-            pInstance.CitizenButton:SetSizeVal(CQUI_SmartWorkIconSize, CQUI_SmartWorkIconSize);
-            pInstance.CitizenButton:SetAlpha(CQUI_SmartWorkIconAlpha);
-          else
-            pInstance.CitizenButton:SetSizeVal(CQUI_WorkIconSize, CQUI_WorkIconSize);
-            pInstance.CitizenButton:SetAlpha(CQUI_WorkIconAlpha);
+        if CQUI_ShowCitizenIconsOnCityHover then
+          -- If this plot is getting worked
+          if workerCount > 0 and kPlot:IsCity() == false then
+            pInstance.CitizenButton:SetHide(false);
+            pInstance.CitizenButton:SetTextureOffsetVal(0, 256);
+            if(CQUI_SmartWorkIcon) then
+              pInstance.CitizenButton:SetSizeVal(CQUI_SmartWorkIconSize, CQUI_SmartWorkIconSize);
+              pInstance.CitizenButton:SetAlpha(CQUI_SmartWorkIconAlpha);
+            else
+              pInstance.CitizenButton:SetSizeVal(CQUI_WorkIconSize, CQUI_WorkIconSize);
+              pInstance.CitizenButton:SetAlpha(CQUI_WorkIconAlpha);
+            end
           end
-        end
 
-        if(tLockedUnits[i] > 0) then
-          pInstance.LockedIcon:SetHide(false);
-          if(CQUI_SmartWorkIcon) then
-            pInstance.LockedIcon:SetAlpha(CQUI_SmartWorkIconAlpha);
+          if(tLockedUnits[i] > 0) then
+            pInstance.LockedIcon:SetHide(false);
+            if(CQUI_SmartWorkIcon) then
+              pInstance.LockedIcon:SetAlpha(CQUI_SmartWorkIconAlpha);
+            else
+              pInstance.LockedIcon:SetAlpha(CQUI_WorkIconAlpha);
+            end
           else
-            pInstance.LockedIcon:SetAlpha(CQUI_WorkIconAlpha);
+            pInstance.LockedIcon:SetHide(true);
           end
-        else
-          pInstance.LockedIcon:SetHide(true);
         end
 
         table.insert(yields, plotId);
@@ -425,7 +427,7 @@ function CQUI_OnBannerMouseExit(playerID: number, cityID: number)
 
   local tPlots    :table = tResults[CityCommandResults.PLOTS];
 
-  if CQUI_ShowCitizenIconsOnCityHover and (tPlots ~= nil and table.count(tPlots) ~= 0) then
+  if (tPlots ~= nil and table.count(tPlots) ~= 0) then
 
     for i,plotId in pairs(tPlots) do
       local kPlot :table = Map.GetPlotByIndex(plotId);

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -83,10 +83,10 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
 INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
   VALUES  ("CQUI_MinimapSize", 512), -- Factor used for setting minimap size (ex: 512 = 512x256). Recommended values fall between 224 and 768, though any positive could work
   ("CQUI_ProductionItemHeight", 32), -- Height used for individual items in the production queue. Recommended values fall between 24 and 128, though any positive could work
-  ("CQUI_SmartWorkIconSize", 80), -- Size used for "smart" work icons. This size is applied to work icons that are currently locked if the smart work icon option is enabled. Recommended values fall between 48 and 128, though any positive multiple of 8 could work (non-multiples are rounded down)
+  ("CQUI_SmartWorkIconSize", 64), -- Size used for "smart" work icons. This size is applied to work icons that are currently locked if the smart work icon option is enabled. Recommended values fall between 48 and 128, though any positive multiple of 8 could work (non-multiples are rounded down)
   ("CQUI_SmartWorkIconAlpha", 40), -- Transparency percent used for "smart" work icons. This alpha is applied to work icons that are currently locked if the smart work icon option is enabled. Recommended values fall between 10 and 100, though any value between 0 and 100 could work
-  ("CQUI_WorkIconSize", 56), -- Size used for work icons. Applies to all icons that aren't flagged using the "smart" work icon feature. Recommended values fall between 48 and 128, though any positive multiple of 8 could work (non-multiples are rounded down)
-  ("CQUI_WorkIconAlpha", 75); -- Size used for work icons. Applies to all icons that aren't flagged using the "smart" work icon feature. Recommended values fall between 10 and 100, though any value between 0 and 100 could work
+  ("CQUI_WorkIconSize", 64), -- Size used for work icons. Applies to all icons that aren't flagged using the "smart" work icon feature. Recommended values fall between 48 and 128, though any positive multiple of 8 could work (non-multiples are rounded down)
+  ("CQUI_WorkIconAlpha", 80); -- Size used for work icons. Applies to all icons that aren't flagged using the "smart" work icon feature. Recommended values fall between 10 and 100, though any value between 0 and 100 could work
 
 /*
     ┌────────────────────────────────────────────────────────────────────────────────────────────┐

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -35,6 +35,7 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
       ("CQUI_AutoapplyArchaeologistLens", 1), -- Automatically activates the archaeologist lens when selecting a archaeologist
       ("CQUI_AutoapplyBuilderLens", 1), -- Automatically activates the builder lens when selecting a builder
       ("CQUI_AutoapplyScoutLens", 1), -- Automatically activates the scout lens when selecting a scout
+      ("CQUI_ShowNothingToDoBuilderLens", 1), -- Shows nothing to do hexes (red tiles) when in builder lens
       ("CQUI_AutoExpandUnitActions", 1), -- Automatically reveals the secondary unit actions normally hidden inside an expando
       ("CQUI_BlockOnCityAttack", 1), -- Block turn from ending if you have a city that can attack
       ("CQUI_ProductionQueue", 1), -- A production queue appears next to the production panel, allowing multiple constructions to be queued at once
@@ -50,7 +51,10 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
       ("CQUI_SmartWorkIcon", 1), -- Applies a different size/transparency to citizen icons if they're currently being worked
       ("CQUI_TechPopupVisual", 0), -- Popups will be displayed when you discover a new tech or civic (this is the normal behavior for the unmoded game)
       ("CQUI_TechPopupAudio", 1), -- Play the voiceovers when you discover a new tech or civic (this is the normal behavior for the unmoded game)
-      ("CQUI_ToggleYieldsOnLoad", 1); -- Toggles yields immediately on load
+      ("CQUI_ToggleYieldsOnLoad", 1), -- Toggles yields immediately on load
+      ('CQUI_ShowCitizenIconsOnCityHover', 0), -- Shows citizen icons when hovering over city banner
+      ('CQUI_ShowCityManageAreaOnCityHover', 1), -- Shows citizen management area when hovering over city banner
+      ('CQUI_ShowCityMangeAreaInScreen', 1); -- Shows citizen management area when in city screen
 
 /*
     ┌────────────────────────────────────────────────────────────────────────────────────────────┐

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -244,12 +244,12 @@ local WorkIconSizeConverter = {
 --Minimum value is 10, maximum is 100. This translates to 91 steps, or 0th step to 90th
 local WorkIconAlphaConverter = {
   ToSteps = function(value)
-    local out = value - 10;
+    local out = value;
     if(out < 0) then out = 0; end
     return out;
   end,
   ToValue = function(steps)
-    local out = steps + 10;
+    local out = steps;
     if(out > 100) then out = 100; end
     return out;
   end,
@@ -300,7 +300,11 @@ function Initialize()
   PopulateCheckBox(Controls.AutoapplyArchaeologistLensCheckbox, "CQUI_AutoapplyArchaeologistLens");
   PopulateCheckBox(Controls.AutoapplyBuilderLensCheckbox, "CQUI_AutoapplyBuilderLens");
   PopulateCheckBox(Controls.AutoapplyScoutLensCheckbox, "CQUI_AutoapplyScoutLens");
+  PopulateCheckBox(Controls.ShowNothingToDoInBuilderLens, "CQUI_ShowNothingToDoBuilderLens", Locale.Lookup("LOC_CQUI_LENSES_SHOWNOTHINGTODO_TOOLTIP"));
   PopulateCheckBox(Controls.ShowYieldsOnCityHoverCheckbox, "CQUI_ShowYieldsOnCityHover", Locale.Lookup("LOC_CQUI_CITYVIEW_SHOWYIELDSONCITYHOVER_TOOLTIP"));
+  PopulateCheckBox(Controls.ShowCitizenIconsOnHoverCheckbox, "CQUI_ShowCitizenIconsOnCityHover", Locale.Lookup("LOC_CQUI_CITYVIEW_SHOWCITIZENICONSONHOVER_TOOLTIP"));
+  PopulateCheckBox(Controls.ShowCityManageAreaOnHoverCheckbox, "CQUI_ShowCityManageAreaOnCityHover", Locale.Lookup("LOC_CQUI_CITYVIEW_SHOWCITYMANAGEONHOVER_TOOLTIP"));
+  PopulateCheckBox(Controls.ShowCityManageAreaInScreenCheckbox, "CQUI_ShowCityMangeAreaInScreen", Locale.Lookup("LOC_CQUI_CITYVIEW_SHOWCITYMANAGEINSCREEN_TOOLTIP"));
   PopulateCheckBox(Controls.ShowUnitPathsCheckbox, "CQUI_ShowUnitPaths");
   PopulateCheckBox(Controls.AutoExpandUnitActionsCheckbox, "CQUI_AutoExpandUnitActions");
   PopulateCheckBox(Controls.AlwaysOpenTechTreesCheckbox, "CQUI_AlwaysOpenTechTrees");
@@ -328,14 +332,14 @@ function Initialize()
 end
 
 function ToggleSmartbannerCheckboxes()
-    local selected = Controls.SmartbannerCheckbox:IsSelected();
-    Controls.SmartbannerCheckboxes:SetHide(not selected);
-    Controls.CityViewStack:ReprocessAnchoring();
+  local selected = Controls.SmartbannerCheckbox:IsSelected();
+  Controls.SmartbannerCheckboxes:SetHide(not selected);
+  Controls.CityViewStack:ReprocessAnchoring();
 end
 function ToggleSmartWorkIconSettings()
-    local selected = Controls.SmartWorkIconCheckbox:IsSelected();
-    Controls.SmartWorkIconSettings:SetHide(not selected);
-    Controls.CityViewStack:ReprocessAnchoring();
+  local selected = Controls.SmartWorkIconCheckbox:IsSelected();
+  Controls.SmartWorkIconSettings:SetHide(not selected);
+  Controls.CityViewStack:ReprocessAnchoring();
 end
 
 Initialize();

--- a/Assets/cqui_settingselement.xml
+++ b/Assets/cqui_settingselement.xml
@@ -79,6 +79,15 @@
             <GridButton ID="ShowYieldsOnCityHoverCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWYIELDSONCITYHOVER" />
           </Stack>
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+            <GridButton ID="ShowCitizenIconsOnHoverCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWCITIZENICONSONHOVER" />
+          </Stack>
+          <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+            <GridButton ID="ShowCityManageAreaOnHoverCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEONHOVER" />
+          </Stack>
+          <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+            <GridButton ID="ShowCityManageAreaInScreenCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWCITYMANAGEINSCREEN" />
+          </Stack>
+          <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <GridButton ID="BlockOnCityAttackCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK" />
           </Stack>
           <Stack Anchor="C,C" StackGrowth="Left">
@@ -114,7 +123,7 @@
             <Label Anchor="L,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_WORKICONALPHA"/>
             <Label String="0" Style="ShellOptionText" Anchor="L,C" ID="WorkIconAlphaText" Offset="3,0" />
           </Stack>
-          <Slider Style="SliderControl" Anchor="C,B" Size="300,13" SpaceForScroll="0" ID="WorkIconAlphaSlider" Steps="90" />
+          <Slider Style="SliderControl" Anchor="C,B" Size="300,13" SpaceForScroll="0" ID="WorkIconAlphaSlider" Steps="100" />
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <GridButton ID="SmartWorkIconCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SMARTWORKICON" />
           </Stack>
@@ -129,7 +138,7 @@
               <Label Anchor="L,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_SMARTWORKICONALPHA"/>
               <Label String="0" Style="ShellOptionText" Anchor="L,C" ID="SmartWorkIconAlphaText" Offset="3,0" />
             </Stack>
-            <Slider Style="SliderControl" Anchor="C,B" Size="300,13" SpaceForScroll="0" ID="SmartWorkIconAlphaSlider" Steps="68" />
+            <Slider Style="SliderControl" Anchor="C,B" Size="300,13" SpaceForScroll="0" ID="SmartWorkIconAlphaSlider" Steps="100" />
           </Stack>
         </Stack>
       </Container>
@@ -384,6 +393,9 @@
           </Stack>
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <GridButton ID="AutoapplyScoutLensCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_LENSES_AUTOAPPLYSCOUTLENS"/>
+          </Stack>
+          <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+            <GridButton ID="ShowNothingToDoInBuilderLens" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_LENSES_SHOWNOTHINGTODO"/>
           </Stack>
         </Stack>
       </Container>

--- a/Integrations/ML/Text/morelenses_text.xml
+++ b/Integrations/ML/Text/morelenses_text.xml
@@ -13,6 +13,9 @@
     <Row Tag="LOC_TOOLTIP_BUILDER_LENS_IMP">
       <Text>Resource/Pillaged/Unique Ability</Text>
     </Row>
+    <Row Tag="LOC_TOOLTIP_RECOMFEATURE_LENS_HILL">
+      <Text>Recommended Improve Feature</Text>
+    </Row>
     <Row Tag="LOC_TOOLTIP_BUILDER_LENS_HILL">
       <Text>Hill</Text>
     </Row>
@@ -41,19 +44,26 @@
     </Row>
 
     <!-- City Overlap Lens -->
-    <Row Tag="LOC_HUD_CITYOVERLAP6_LENS">
-        <Text>City Overlap 6</Text>
+    <Row Tag="LOC_HUD_CITYOVERLAP_LENS">
+      <Text>City Overlap</Text>
     </Row>
-    <Row Tag="LOC_HUD_CITYOVERLAP6_LENS_TOOLTIP">
+    <Row Tag="LOC_HUD_CITYOVERLAP_LENS_TOOLTIP">
       <Text>Shows how many cities (in range of 6 hexes) a hex overlaps with</Text>
     </Row>
-
-    <!-- City Overlap Lens -->
-    <Row Tag="LOC_HUD_CITYOVERLAP9_LENS">
-      <Text>City Overlap 9</Text>
+    <Row Tag="LOC_PANEL_CITYOVERLAP_OPTION1">
+      <Text>Highlight outside border</Text>
     </Row>
-    <Row Tag="LOC_HUD_CITYOVERLAP9_LENS_TOOLTIP">
-      <Text>Shows how many cities (in range of 9 hexes) a hex overlaps with</Text>
+    <Row Tag="LOC_PANEL_CITYOVERLAP_NMOUSE">
+        <Text>No Mouse</Text>
+    </Row>
+    <Row Tag="LOC_PANEL_CITYOVERLAP_RANGE">
+      <Text>Range Mouse</Text>
+    </Row>
+    <Row Tag="LOC_TOOLTIP_CITYOVERLAP_RANGE">
+      <Text>Shows tiles and highlights cities within range (set below) from the tile under the mouse.</Text>
+    </Row>
+    <Row Tag="LOC_PANEL_CITYOVERLAP_RADIUS">
+      <Text>Radius Mouse</Text>
     </Row>
 
     <!-- Barbarian Lens -->
@@ -124,6 +134,23 @@
     </Row>
     <Row Tag="LOC_TOOLTIP_SCOUT_LENS_GHUT">
       <Text>Goody Hut</Text>
+    </Row>
+
+    <!-- Naturalist Lens -->
+    <Row Tag="LOC_HUD_NATURALIST_LENS">
+      <Text>Naturalist</Text>
+    </Row>
+    <Row Tag="LOC_HUD_NATURALIST_LENS_TOOLTIP">
+      <Text>Highlights places where National Parks can be built</Text>
+    </Row>
+    <Row Tag="LOC_TOOLTIP_NATURALIST_LENS_NPARK">
+      <Text>Area is ready for National Park</Text>
+    </Row>
+    <Row Tag="LOC_TOOLTIP_NATURALIST_LENS_OK">
+      <Text>Tile could be used, if some other plot is fixed</Text>
+    </Row>
+    <Row Tag="LOC_TOOLTIP_NATURALIST_LENS_FIXABLE">
+      <Text>Needs fixing to be used for a park</Text>
     </Row>
 
   </BaseGameText>

--- a/Integrations/ML/UI/Panels/modallenspanel.lua
+++ b/Integrations/ML/UI/Panels/modallenspanel.lua
@@ -2,25 +2,34 @@
 
 include( "InstanceManager" );
 
-local m_KeyStackIM:table = InstanceManager:new( "KeyEntry", "KeyColorImage", Controls.KeyStack );
-local m_ContinentColorList:table = {};
-local m_CurrentModdedLensOn;
-
 -- Similiar to MinimapPanel.lua to control modded lenses
 -- Used to control ModalLensPanel.lua
 local MODDED_LENS_ID:table = {
-  NONE 			= 0;
-  APPEAL 			= 1;
-  BUILDER 		= 2;
-  ARCHAEOLOGIST 	= 3;
-  BARBARIAN 		= 4;
-  CITY_OVERLAP6 	= 5;
-  CITY_OVERLAP9 	= 6;
-  RESOURCE 		= 7;
-  WONDER 			= 8;
-  ADJACENCY_YIELD = 9;
-  SCOUT 			= 10;
+  NONE = 0;
+  APPEAL = 1;
+  BUILDER = 2;
+  ARCHAEOLOGIST = 3;
+  BARBARIAN = 4;
+  CITY_OVERLAP = 5;
+  RESOURCE = 6;
+  WONDER = 7;
+  ADJACENCY_YIELD = 8;
+  SCOUT = 9;
+  NATURALIST = 10;
+  CUSTOM = 11;
 };
+
+-- Different from above, since it uses a government lens, instead of appeal
+local AREA_LENS_ID:table = {
+  NONE = 0;
+  GOVERNMENT = 1;
+  CITIZEN_MANAGEMENT = 2;
+}
+
+local m_KeyStackIM:table = InstanceManager:new( "KeyEntry", "KeyColorImage", Controls.KeyStack );
+local m_ContinentColorList:table = {};
+local m_CurrentModdedLensOn = MODDED_LENS_ID.NONE;
+local m_CurrentAreaLensOn = AREA_LENS_ID.NONE;
 
 --============================================================================
 function Close()
@@ -56,6 +65,8 @@ function ShowBuilderLensKey()
   m_KeyStackIM: ResetInstances();
 
   AddKeyEntry("LOC_TOOLTIP_BUILDER_LENS_IMP", UI.GetColorValue("COLOR_RESOURCE_BUILDER_LENS"));
+
+  AddKeyEntry("LOC_TOOLTIP_RECOMFEATURE_LENS_HILL", UI.GetColorValue("COLOR_RECOMFEATURE_BUILDER_LENS"));
 
   AddKeyEntry("LOC_TOOLTIP_BUILDER_LENS_HILL", UI.GetColorValue("COLOR_HILL_BUILDER_LENS"));
 
@@ -180,7 +191,7 @@ function ShowPoliticalLensKey()
 end
 
 --============================================================================
-function ShowCityOverlap6LensKey()
+function ShowCityOverlapLensKey()
   m_KeyStackIM: ResetInstances();
 
   for i = 1, 8 do
@@ -197,7 +208,7 @@ function ShowCityOverlap6LensKey()
     end
 
     local colorLookup:string = "COLOR_GRADIENT8_" .. tostring(i);
-    print(colorLookup);
+    -- print(colorLookup);
     local color:number = UI.GetColorValue(colorLookup);
     AddKeyEntryAlt(s, color);
   end
@@ -221,22 +232,22 @@ end
 function ShowResourceLensKey()
   m_KeyStackIM: ResetInstances();
 
-  local LuxConnectedColor		:number = UI.GetColorValue("COLOR_LUXCONNECTED_RES_LENS");
+  local LuxConnectedColor     :number = UI.GetColorValue("COLOR_LUXCONNECTED_RES_LENS");
   AddKeyEntry("LOC_TOOLTIP_RESOURCE_LENS_LUXURY", LuxConnectedColor);
 
-  local LuxNConnectedColor	:number = UI.GetColorValue("COLOR_LUXNCONNECTED_RES_LENS");
+  local LuxNConnectedColor    :number = UI.GetColorValue("COLOR_LUXNCONNECTED_RES_LENS");
   AddKeyEntry("LOC_TOOLTIP_RESOURCE_LENS_NLUXURY", LuxNConnectedColor);
 
-  local BonusConnectedColor	:number = UI.GetColorValue("COLOR_BONUSCONNECTED_RES_LENS");
+  local BonusConnectedColor   :number = UI.GetColorValue("COLOR_BONUSCONNECTED_RES_LENS");
   AddKeyEntry("LOC_TOOLTIP_RESOURCE_LENS_BONUS", BonusConnectedColor);
 
-  local BonusNConnectedColor	:number = UI.GetColorValue("COLOR_BONUSNCONNECTED_RES_LENS");
+  local BonusNConnectedColor  :number = UI.GetColorValue("COLOR_BONUSNCONNECTED_RES_LENS");
   AddKeyEntry("LOC_TOOLTIP_RESOURCE_LENS_NBONUS", BonusNConnectedColor);
 
-  local StratConnectedColor	:number = UI.GetColorValue("COLOR_STRATCONNECTED_RES_LENS");
+  local StratConnectedColor   :number = UI.GetColorValue("COLOR_STRATCONNECTED_RES_LENS");
   AddKeyEntry("LOC_TOOLTIP_RESOURCE_LENS_STRATEGIC", StratConnectedColor);
 
-  local StratNConnectedColor	:number = UI.GetColorValue("COLOR_STRATNCONNECTED_RES_LENS");
+  local StratNConnectedColor  :number = UI.GetColorValue("COLOR_STRATNCONNECTED_RES_LENS");
   AddKeyEntry("LOC_TOOLTIP_RESOURCE_LENS_NSTRATEGIC", StratNConnectedColor);
 
   Controls.KeyPanel:SetHide(false);
@@ -247,10 +258,10 @@ end
 function ShowWonderLensKey()
   m_KeyStackIM: ResetInstances();
 
-  local NaturalWonderColor 	:number = UI.GetColorValue("COLOR_NATURAL_WONDER_LENS");
+  local NaturalWonderColor    :number = UI.GetColorValue("COLOR_NATURAL_WONDER_LENS");
   AddKeyEntry("LOC_TOOLTIP_WONDER_LENS_NWONDER", NaturalWonderColor);
 
-  local PlayerWonderColor 	:number = UI.GetColorValue("COLOR_PLAYER_WONDER_LENS");
+  local PlayerWonderColor     :number = UI.GetColorValue("COLOR_PLAYER_WONDER_LENS");
   AddKeyEntry("LOC_TOOLTIP_RESOURCE_LENS_PWONDER", PlayerWonderColor);
 
   Controls.KeyPanel:SetHide(false);
@@ -271,7 +282,7 @@ function ShowAdjacencyYieldLensKey()
     end
 
     local colorLookup:string = "COLOR_GRADIENT8_" .. tostring(i);
-    print(colorLookup);
+        -- print(colorLookup);
     local color:number = UI.GetColorValue(colorLookup);
     AddKeyEntryAlt(s, color);
   end
@@ -284,8 +295,21 @@ end
 function ShowScoutLensKey()
   m_KeyStackIM: ResetInstances();
 
-  local GoodyHutColor 	:number = UI.GetColorValue("COLOR_GHUT_SCOUT_LENS");
+  local GoodyHutColor     :number = UI.GetColorValue("COLOR_GHUT_SCOUT_LENS");
   AddKeyEntry("LOC_TOOLTIP_SCOUT_LENS_GHUT", GoodyHutColor);
+
+  Controls.KeyPanel:SetHide(false);
+  Controls.KeyScrollPanel:CalculateSize();
+end
+
+--============================================================================
+function ShowNaturalistLensKey()
+  m_KeyStackIM: ResetInstances();
+
+  local parkNaturalistLens     :number = UI.GetColorValue("COLOR_PARK_NATURALIST_LENS");
+  AddKeyEntry("LOC_TOOLTIP_NATURALIST_LENS_NPARK", parkNaturalistLens);
+  AddKeyEntry("LOC_TOOLTIP_NATURALIST_LENS_OK", UI.GetColorValue("COLOR_OK_NATURALIST_LENS"));
+  AddKeyEntry("LOC_TOOLTIP_NATURALIST_LENS_FIXABLE", UI.GetColorValue("COLOR_FIXABLE_NATURALIST_LENS"));
 
   Controls.KeyPanel:SetHide(false);
   Controls.KeyScrollPanel:CalculateSize();
@@ -391,22 +415,7 @@ function AddKeyEntryAlt(textString:string, colorValue:number, bonusIcon:string, 
 end
 
 -- ===========================================================================
-function GetCurrentModdedLens()
-  -- local localPlayerID = Game.GetLocalPlayer();
-  -- if(PlayerConfigurations[localPlayerID]:GetValue("ModdedLens_CurrentModdedLensOn") ~= nil) then
-  -- 	local dataDump = PlayerConfigurations[localPlayerID]:GetValue("ModdedLens_CurrentModdedLensOn");
-  -- 	print("Get: " .. dataDump);
-  -- 	loadstring(dataDump)();
-  -- 	m_CurrentModdedLensOn = currentModdedLensOn;
-  -- else
-  -- 	print("No modded lens data was found.")
-  -- end
-  return m_CurrentModdedLensOn;
-end
-
--- ===========================================================================
 function OnLensLayerOn( layerNum:number )
-  -- print("Lens layer on " .. layerNum);
   if layerNum == LensLayers.HEX_COLORING_RELIGION then
     Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_RELIGION_LENS")));
     Controls.KeyPanel:SetHide(true);
@@ -415,40 +424,48 @@ function OnLensLayerOn( layerNum:number )
     Controls.KeyPanel:SetHide(true);
     ShowContinentLensKey();
   elseif layerNum == LensLayers.HEX_COLORING_APPEAL_LEVEL then
-    if GetCurrentModdedLens() == MODDED_LENS_ID.APPEAL then
+    -- print("Modded Lens on " .. m_CurrentModdedLensOn);
+    if m_CurrentModdedLensOn == MODDED_LENS_ID.APPEAL then
       Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_APPEAL_LENS")));
       ShowAppealLensKey();
-    elseif GetCurrentModdedLens() == MODDED_LENS_ID.BUILDER then
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.BUILDER then
       Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_BUILDER_LENS")));
       ShowBuilderLensKey();
-    elseif GetCurrentModdedLens() == MODDED_LENS_ID.ARCHAEOLOGIST then
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.ARCHAEOLOGIST then
       Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_ARCHAEOLOGIST_LENS")));
       ShowArchaeologistLensKey();
-    elseif GetCurrentModdedLens() == MODDED_LENS_ID.CITY_OVERLAP6 then
-      Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_CITYOVERLAP6_LENS")));
-      ShowCityOverlap6LensKey();
-    elseif GetCurrentModdedLens() == MODDED_LENS_ID.CITY_OVERLAP9 then
-      Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_CITYOVERLAP9_LENS")));
-      ShowCityOverlap6LensKey(); -- TODO Create a custom key
-    elseif GetCurrentModdedLens() == MODDED_LENS_ID.BARBARIAN then
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.CITY_OVERLAP then
+      Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_CITYOVERLAP_LENS")));
+      ShowCityOverlapLensKey();
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.BARBARIAN then
       Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_BARBARIAN_LENS")));
       ShowBarbarianLensKey();
-    elseif GetCurrentModdedLens() == MODDED_LENS_ID.RESOURCE then
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.RESOURCE then
       Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_RESOURCE_LENS")));
       ShowResourceLensKey();
-    elseif GetCurrentModdedLens() == MODDED_LENS_ID.WONDER then
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.WONDER then
       Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_WONDER_LENS")));
       ShowWonderLensKey();
-    elseif GetCurrentModdedLens() == MODDED_LENS_ID.ADJACENCY_YIELD then
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.ADJACENCY_YIELD then
       Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_ADJYIELD_LENS")));
       ShowAdjacencyYieldLensKey();
-    elseif GetCurrentModdedLens() == MODDED_LENS_ID.SCOUT then
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.SCOUT then
       Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_SCOUT_LENS")));
       ShowScoutLensKey();
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.NATURALIST then
+      Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_NATURALIST_LENS")));
+      ShowNaturalistLensKey();
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.CUSTOM then
+      print("Hiding")
+      ContextPtr:SetHide(true);   -- Hide the Modal Panel if custom
     end
   elseif layerNum == LensLayers.HEX_COLORING_GOVERNMENT then
-    Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_GOVERNMENT_LENS")));
-    ShowGovernmentLensKey();
+    if m_CurrentAreaLensOn == AREA_LENS_ID.GOVERNMENT then
+      Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_GOVERNMENT_LENS")));
+      ShowGovernmentLensKey();
+    -- else
+       -- Add extra area lenses here
+    end
   elseif layerNum == LensLayers.HEX_COLORING_OWING_CIV then
     Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_OWNER_LENS")));
     ShowPoliticalLensKey();
@@ -462,14 +479,19 @@ function OnLensLayerOn( layerNum:number )
 end
 
 -- ===========================================================================
--- Called from
-function OnModdedLensOn(modID)
-  print("Current modded lens on " .. modID);
-  m_CurrentModdedLensOn = modID;
+-- Called from MinimapPanel.lua
+function OnModdedLensOn(lensID)
+    print("Current modded lens on " .. lensID);
+    m_CurrentModdedLensOn = lensID;
+end
+
+function OnAreaLensOn(lensID)
+    print("Current area lens on " .. lensID);
+    m_CurrentAreaLensOn = lensID;
 end
 
 -- ===========================================================================
---	Game Engine Event
+--  Game Engine Event
 -- ===========================================================================
 function OnInterfaceModeChanged(eOldMode:number, eNewMode:number)
   if eNewMode == InterfaceModeTypes.VIEW_MODAL_LENS then
@@ -481,7 +503,7 @@ function OnInterfaceModeChanged(eOldMode:number, eNewMode:number)
 end
 
 -- ===========================================================================
---	INIT (ModalLensPanel)
+--  INIT (ModalLensPanel)
 -- ===========================================================================
 function InitializeModalLensPanel()
   print("Initializing ModalLensPanel")
@@ -496,5 +518,6 @@ function InitializeModalLensPanel()
 
   LuaEvents.MinimapPanel_AddContinentColorPair.Add(OnAddContinentColorPair);
   LuaEvents.MinimapPanel_ModdedLensOn.Add(OnModdedLensOn);
+  LuaEvents.MinimapPanel_AreaLensOn.Add(OnAreaLensOn);
 end
 InitializeModalLensPanel();

--- a/Integrations/ML/UI/minimappanel.lua
+++ b/Integrations/ML/UI/minimappanel.lua
@@ -9,6 +9,8 @@ include( "SupportFunctions" );
 --  CONSTANTS
 -- ===========================================================================
 local MINIMAP_COLLAPSED_OFFSETY :number = -180;
+local LENS_PANEL_OFFSET:number = 50;
+local MINIMAP_BACKING_PADDING_SIZEY:number = 60;
 
 -- Used to control ModalLensPanel.lua
 local MODDED_LENS_ID:table = {
@@ -17,24 +19,41 @@ local MODDED_LENS_ID:table = {
   BUILDER = 2;
   ARCHAEOLOGIST = 3;
   BARBARIAN = 4;
-  CITY_OVERLAP6 = 5;
-  CITY_OVERLAP9 = 6;
-  RESOURCE = 7;
-  WONDER = 8;
-  ADJACENCY_YIELD = 9;
-  SCOUT = 10;
+  CITY_OVERLAP = 5;
+  RESOURCE = 6;
+  WONDER = 7;
+  ADJACENCY_YIELD = 8;
+  SCOUT = 9;
+  NATURALIST = 10;
+  CUSTOM = 11;
 };
+
+-- Different from above, since it uses a government lens, instead of appeal
+local AREA_LENS_ID:table = {
+  NONE = 0;
+  GOVERNMENT = 1;
+  CITIZEN_MANAGEMENT = 2;
+}
 
 -- Should the builder lens auto apply, when a builder is selected.
 local AUTO_APPLY_BUILDER_LENS:boolean = true;
 
--- Should the archeologist lens auto apply, when a archeologist is selected.
+-- Should the archaeologist lens auto apply, when a archaeologist is selected.
 local AUTO_APPLY_ARCHEOLOGIST_LENS:boolean = true
 
 -- Should the scout lens auto apply, when a scout/ranger is selected.
 local AUTO_APPLY_SCOUT_LENS:boolean = true;
 
-local m_isModdedMouseFeatureEnabled = true;
+-- Show citizen management area when hovering over city plot
+local SHOW_CITIZEN_MANAGEMENT_ONHOVER:boolean = false;
+
+-- Show citizen management when managing citizens
+local SHOW_CITIZEN_MANAGEMENT_INSCREEN:boolean = true;
+
+-- Highlight nothing to do (red plots) in builder lens
+local HIGHLIGHT_NOTHING_TODO_IN_BUILDER_LENS:boolean = false;
+
+local CITY_WORK_RANGE:number = 3;
 
 -- ===========================================================================
 --  MEMBERS
@@ -67,16 +86,37 @@ local m_ToggleSettlerLensId     = Input.GetActionId("LensSettler");
 local m_ToggleGovernmentLensId  = Input.GetActionId("LensGovernment");
 local m_TogglePoliticalLensId   = Input.GetActionId("LensPolitical");
 local m_ToggleTourismLensId     = Input.GetActionId("LensTourism");
-
+local m_Toggle2DViewId          = Input.GetActionId("Toggle2DView");
 
 local m_isMouseDragEnabled      :boolean = true; -- Can the camera be moved by dragging on the minimap?
 local m_isMouseDragging         :boolean = false; -- Was LMB clicked inside the minimap, and has not been released yet?
 local m_hasMouseDragged         :boolean = false; -- Has there been any movements since m_isMouseDragging became true?
 local m_wasMouseInMinimap       :boolean = false; -- Was the mouse over the minimap the last time we checked?
 
+local m_CurrentModdedLensOn     :number  = MODDED_LENS_ID.NONE;
+local m_CurrentAreaLensOn       :number  = AREA_LENS_ID.NONE;
+
+local m_CustomLens_PlotsAndColors:table = {}
+
+-- Resource Lens Specific Vars
+local ResourcesToHide:table = {};
+local ResourceCategoryToHide:table = {};
+
+local m_CityOverlapRange:number = 6;
+
+local m_CurrentCursorPlotID:number = -1;
+
+-- Citizen management lens variables
+local m_EnableCitizenManagementArea:boolean = true;
+local m_CitizenManagementOn:boolean = false;
+local m_FullClearAreaLens:boolean = true;
+local m_tAreaPlotsColored:table = {}
+
+-- Settler Lens Variables
+local m_CtrlDown:boolean = false;
+
 local CQUI_MapSize = 512;
 
-local m_CurrentModdedLensOn     :number  = MODDED_LENS_ID.NONE;
 -- ===========================================================================
 --  FUNCTIONS
 -- ===========================================================================
@@ -195,16 +235,16 @@ end
 
 -- ===========================================================================
 function RefreshMinimapOptions()
-    Controls.ToggleYieldsButton:SetCheck(UserConfiguration.ShowMapYield());
-    Controls.ToggleResourcesButton:SetCheck(UserConfiguration.ShowMapResources());
-    Controls.ToggleGridButton:SetCheck(bGridOn);
+  Controls.ToggleYieldsButton:SetCheck(UserConfiguration.ShowMapYield());
+  Controls.ToggleGridButton:SetCheck(bGridOn);
+  Controls.ToggleResourcesButton:SetCheck(UserConfiguration.ShowMapResources());
 end
 
 -- ===========================================================================
 function ToggleMapOptionsList()
-    if Controls.MapOptionsPanel:IsHidden() then
-        RefreshMinimapOptions();
-    end
+  if Controls.MapOptionsPanel:IsHidden() then
+      RefreshMinimapOptions();
+  end
   Controls.MapOptionsPanel:SetHide( not Controls.MapOptionsPanel:IsHidden() );
   RealizeFlyouts(Controls.MapOptionsPanel);
   Controls.MapOptionsButton:SetSelected( not Controls.MapOptionsPanel:IsHidden() );
@@ -215,6 +255,7 @@ function OnToggleLensList()
   Controls.LensPanel:SetHide( not Controls.LensPanel:IsHidden() );
   RealizeFlyouts(Controls.LensPanel);
   Controls.LensButton:SetSelected( not Controls.LensPanel:IsHidden() );
+  Controls.LensChooserList:CalculateSize();
   if Controls.LensPanel:IsHidden() then
     m_shouldCloseLensMenu = true;
     Controls.ReligionLensButton:SetCheck(false);
@@ -231,17 +272,32 @@ function OnToggleLensList()
     Controls.WonderLensButton:SetCheck(false);
     Controls.ResourceLensButton:SetCheck(false);
     Controls.BarbarianLensButton:SetCheck(false);
-    Controls.CityOverlap9LensButton:SetCheck(false);
-    Controls.CityOverlap6LensButton:SetCheck(false);
+    Controls.CityOverlapLensButton:SetCheck(false);
     Controls.ArchaeologistLensButton:SetCheck(false);
     Controls.BuilderLensButton:SetCheck(false);
+    Controls.NaturalistLensButton:SetCheck(false);
+
+    -- Side Menus
+    Controls.ResourceLensOptionsPanel:SetHide(true);
+    Controls.OverlapLensOptionsPanel:SetHide(true);
+
     if UI.GetInterfaceMode() == InterfaceModeTypes.VIEW_MODAL_LENS then
       UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
     end
+  else
+    Controls.ReligionLensButton:SetHide(not GameCapabilities.HasCapability("CAPABILITY_LENS_RELIGION"));
+    Controls.AppealLensButton:SetHide(not GameCapabilities.HasCapability("CAPABILITY_LENS_APPEAL"));
+    Controls.GovernmentLensButton:SetHide(not GameCapabilities.HasCapability("CAPABILITY_LENS_GOVERNMENT"));
+    Controls.WaterLensButton:SetHide(not GameCapabilities.HasCapability("CAPABILITY_LENS_SETTLER"));
+    Controls.TourismLensButton:SetHide(not GameCapabilities.HasCapability("CAPABILITY_LENS_TOURISM"));
+    -- Controls.LensToggleStack:CalculateSize();
+
+    -- Don't call this otherwise the panel is ridiculously long
+    -- Controls.LensPanel:SetSizeY(Controls.LensToggleStack:GetSizeY() + LENS_PANEL_OFFSET);
   end
 end
 
-------------------------------------------------------------------------------
+-- ===========================================================================
 function ToggleMapPinMode()
   Controls.MapPinListPanel:SetHide( not Controls.MapPinListPanel:IsHidden() );
   RealizeFlyouts(Controls.MapPinListPanel);
@@ -270,10 +326,10 @@ function ToggleReligionLens()
     UILens.SetActive("Religion");
     RefreshInterfaceMode();
   else
-      m_shouldCloseLensMenu = false; --When toggling the lens off, shouldn't close the menu.
-      if UI.GetInterfaceMode() == InterfaceModeTypes.VIEW_MODAL_LENS then
-        UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
-      end
+    m_shouldCloseLensMenu = false; --When toggling the lens off, shouldn't close the menu.
+    if UI.GetInterfaceMode() == InterfaceModeTypes.VIEW_MODAL_LENS then
+      UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
+    end
   end
 end
 
@@ -281,8 +337,8 @@ end
 function ToggleContinentLens()
   if Controls.ContinentLensButton:IsChecked() then
     UILens.SetActive("Continent");
-  else
     RefreshInterfaceMode();
+  else
     m_shouldCloseLensMenu = false;
     if UI.GetInterfaceMode() == InterfaceModeTypes.VIEW_MODAL_LENS then
       UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
@@ -302,7 +358,6 @@ function ToggleAppealLens()
     end
 
     UILens.SetActive("Appeal");
-
     RefreshInterfaceMode();
   else
     m_shouldCloseLensMenu = false;
@@ -329,6 +384,14 @@ end
 -- ===========================================================================
 function ToggleGovernmentLens()
   if Controls.GovernmentLensButton:IsChecked() then
+    SetActiveAreaLens(AREA_LENS_ID.GOVERNMENT);
+
+    -- Check if the gov lens is already active. Needed to clear any gov lens
+    if UILens.IsLayerOn(LensLayers.HEX_COLORING_GOVERNMENT) then
+      -- Unapply the appeal lens, so it can be cleared from the screen
+      UILens.SetActive("Default");
+    end
+
     UILens.SetActive("Government");
     RefreshInterfaceMode();
   else
@@ -336,6 +399,7 @@ function ToggleGovernmentLens()
     if UI.GetInterfaceMode() == InterfaceModeTypes.VIEW_MODAL_LENS then
       UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
     end
+    SetActiveAreaLens(AREA_LENS_ID.NONE);
   end
 end
 
@@ -368,7 +432,6 @@ end
 -- ===========================================================================
 -- Modded lenses
 -- ===========================================================================
--- ===========================================================================
 function ToggleBuilderLens()
   if Controls.BuilderLensButton:IsChecked() then
     SetActiveModdedLens(MODDED_LENS_ID.BUILDER);
@@ -380,7 +443,6 @@ function ToggleBuilderLens()
     end
 
     UILens.SetActive("Appeal");
-
     RefreshInterfaceMode();
   else
     m_shouldCloseLensMenu = false;
@@ -403,7 +465,6 @@ function ToggleArchaeologistLens()
     end
 
     UILens.SetActive("Appeal");
-
     RefreshInterfaceMode();
   else
     m_shouldCloseLensMenu = false;
@@ -415,9 +476,9 @@ function ToggleArchaeologistLens()
 end
 
 -- ===========================================================================
-function ToggleCityOverlap6Lens()
-  if Controls.CityOverlap6LensButton:IsChecked() then
-    SetActiveModdedLens(MODDED_LENS_ID.CITY_OVERLAP6);
+function ToggleCityOverlapLens()
+  if Controls.CityOverlapLensButton:IsChecked() then
+    SetActiveModdedLens(MODDED_LENS_ID.CITY_OVERLAP);
 
     -- Check if the appeal lens is already active
     if UILens.IsLayerOn(LensLayers.HEX_COLORING_APPEAL_LEVEL) then
@@ -428,34 +489,13 @@ function ToggleCityOverlap6Lens()
     UILens.SetActive("Appeal");
 
     RefreshInterfaceMode();
+    Controls.OverlapLensOptionsPanel:SetHide(false);
   else
     m_shouldCloseLensMenu = false;
     if UI.GetInterfaceMode() == InterfaceModeTypes.VIEW_MODAL_LENS then
       UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
     end
-    SetActiveModdedLens(MODDED_LENS_ID.NONE);
-  end
-end
-
--- ===========================================================================
-function ToggleCityOverlap9Lens()
-  if Controls.CityOverlap9LensButton:IsChecked() then
-    SetActiveModdedLens(MODDED_LENS_ID.CITY_OVERLAP9);
-
-    -- Check if the appeal lens is already active
-    if UILens.IsLayerOn(LensLayers.HEX_COLORING_APPEAL_LEVEL) then
-      -- Unapply the appeal lens, so it can be cleared from the screen
-      UILens.SetActive("Default");
-    end
-
-    UILens.SetActive("Appeal");
-
-    RefreshInterfaceMode();
-  else
-    m_shouldCloseLensMenu = false;
-    if UI.GetInterfaceMode() == InterfaceModeTypes.VIEW_MODAL_LENS then
-      UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
-    end
+    Controls.OverlapLensOptionsPanel:SetHide(true);
     SetActiveModdedLens(MODDED_LENS_ID.NONE);
   end
 end
@@ -472,7 +512,6 @@ function ToggleBarbarianLens()
     end
 
     UILens.SetActive("Appeal");
-
     RefreshInterfaceMode();
   else
     m_shouldCloseLensMenu = false;
@@ -496,12 +535,16 @@ function ToggleResourceLens()
 
     UILens.SetActive("Appeal");
 
+    RefreshResourcePicker();
     RefreshInterfaceMode();
+
+    Controls.ResourceLensOptionsPanel:SetHide(false);
   else
     m_shouldCloseLensMenu = false;
     if UI.GetInterfaceMode() == InterfaceModeTypes.VIEW_MODAL_LENS then
       UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
     end
+    Controls.ResourceLensOptionsPanel:SetHide(true);
     SetActiveModdedLens(MODDED_LENS_ID.NONE);
   end
 end
@@ -518,7 +561,6 @@ function ToggleWonderLens()
     end
 
     UILens.SetActive("Appeal");
-
     RefreshInterfaceMode();
   else
     m_shouldCloseLensMenu = false;
@@ -541,7 +583,6 @@ function ToggleAdjacencyYieldLens()
     end
 
     UILens.SetActive("Appeal");
-
     RefreshInterfaceMode();
   else
     m_shouldCloseLensMenu = false;
@@ -564,7 +605,6 @@ function ToggleScoutLens()
     end
 
     UILens.SetActive("Appeal");
-
     RefreshInterfaceMode();
   else
     m_shouldCloseLensMenu = false;
@@ -575,6 +615,31 @@ function ToggleScoutLens()
   end
 end
 
+-- ===========================================================================
+function ToggleNaturalistLens()
+  if Controls.NaturalistLensButton:IsChecked() then
+    SetActiveModdedLens(MODDED_LENS_ID.NATURALIST);
+
+    -- Check if the appeal lens is already active
+    if UILens.IsLayerOn(LensLayers.HEX_COLORING_APPEAL_LEVEL) then
+      -- Unapply the appeal lens, so it can be cleared from the screen
+      UILens.SetActive("Default");
+    end
+
+    UILens.SetActive("Appeal");
+    RefreshInterfaceMode();
+  else
+    m_shouldCloseLensMenu = false;
+    if UI.GetInterfaceMode() == InterfaceModeTypes.VIEW_MODAL_LENS then
+      UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
+    end
+    SetActiveModdedLens(MODDED_LENS_ID.NONE);
+  end
+end
+
+-- ===========================================================================
+-- Remaining MINIMAP
+-- Resize functions, callbacks, etc
 -- ===========================================================================
 function ToggleGrid()
   bGridOn = not bGridOn;
@@ -607,8 +672,7 @@ function OnCollapseToggle()
   if ( m_isCollapsed ) then
     UI.PlaySound("Minimap_Open");
     Controls.ExpandButton:SetHide( true );
-    Controls.CollapseButton:SetHide( false );
-    Controls.ExpandAnim:SetEndVal(0, -Controls.MinimapImage:GetOffsetY() - Controls.MinimapImage:GetSizeY() + 25);
+    Controls.ExpandAnim:SetEndVal(0, -Controls.MinimapContainer:GetOffsetY() - Controls.MinimapContainer:GetSizeY());
     Controls.ExpandAnim:SetToBeginning();
     Controls.ExpandAnim:Play();
     Controls.CompassArm:SetPercent(.25);
@@ -617,7 +681,7 @@ function OnCollapseToggle()
     Controls.ExpandButton:SetHide( false );
     Controls.CollapseButton:SetHide( true );
     Controls.Pause:Play();
-    Controls.CollapseAnim:SetEndVal(0, Controls.MinimapImage:GetOffsetY() + Controls.MinimapImage:GetSizeY() - 25);
+    Controls.CollapseAnim:SetEndVal(0, Controls.MinimapContainer:GetOffsetY() + Controls.MinimapContainer:GetSizeY());
     Controls.CollapseAnim:SetToBeginning();
     Controls.CollapseAnim:Play();
     Controls.CompassArm:SetPercent(.5);
@@ -626,10 +690,23 @@ function OnCollapseToggle()
 end
 
 -- ===========================================================================
+function OnMinimapImageSizeChanged()
+  ResizeBacking();
+end
+
+-- ===========================================================================
+function ResizeBacking()
+  Controls.MinimapBacking:SetSizeY(Controls.MinimapImage:GetSizeY() + MINIMAP_BACKING_PADDING_SIZEY);
+end
+
+-- ===========================================================================
 function RefreshInterfaceMode()
   if UI.GetInterfaceMode() ~= InterfaceModeTypes.VIEW_MODAL_LENS then
     UI.SetInterfaceMode(InterfaceModeTypes.VIEW_MODAL_LENS);
   end
+
+  Controls.ResourceLensOptionsPanel:SetHide(true);
+  Controls.OverlapLensOptionsPanel:SetHide(true);
 end
 
 -- ===========================================================================
@@ -637,32 +714,36 @@ function OnLensLayerOn( layerNum:number )
   if layerNum == LensLayers.HEX_COLORING_RELIGION then
     UI.PlaySound("UI_Lens_Overlay_On");
   elseif layerNum == LensLayers.HEX_COLORING_APPEAL_LEVEL then
-    local currentModdedLens = GetCurrentModdedLens();
-    if currentModdedLens == MODDED_LENS_ID.APPEAL then
+    if m_CurrentModdedLensOn == MODDED_LENS_ID.APPEAL then
       SetAppealHexes();
-    elseif currentModdedLens == MODDED_LENS_ID.BUILDER then
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.BUILDER then
       SetBuilderLensHexes();
-    elseif currentModdedLens == MODDED_LENS_ID.ARCHAEOLOGIST then
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.ARCHAEOLOGIST then
       SetArchaeologistLens();
-    elseif currentModdedLens == MODDED_LENS_ID.CITY_OVERLAP6 then
-      SetCityOverlapLens(6);
-    elseif currentModdedLens == MODDED_LENS_ID.CITY_OVERLAP9 then
-      SetCityOverlapLens(9);
-    elseif currentModdedLens == MODDED_LENS_ID.BARBARIAN then
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.CITY_OVERLAP then
+      SetCityOverlapLens();
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.BARBARIAN then
       SetBarbarianLens();
-    elseif currentModdedLens == MODDED_LENS_ID.RESOURCE then
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.RESOURCE then
       SetResourceLens();
-    elseif currentModdedLens == MODDED_LENS_ID.WONDER then
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.WONDER then
       SetWonderLens();
-    elseif currentModdedLens == MODDED_LENS_ID.ADJACENCY_YIELD then
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.ADJACENCY_YIELD then
       SetAdjacencyYieldLens();
-    elseif currentModdedLens == MODDED_LENS_ID.SCOUT then
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.SCOUT then
       SetScoutLens();
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.NATURALIST then
+      SetNaturalistLens();
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.CUSTOM then
+      SetCustomLens();
     end
     UI.PlaySound("UI_Lens_Overlay_On");
   elseif layerNum == LensLayers.HEX_COLORING_GOVERNMENT then
-    SetGovernmentHexes();
-    UI.PlaySound("UI_Lens_Overlay_On");
+    if m_CurrentAreaLensOn == AREA_LENS_ID.GOVERNMENT then
+      SetGovernmentHexes();
+      UI.PlaySound("UI_Lens_Overlay_On");
+      -- else Extra Area Lenses go here
+    end
   elseif layerNum == LensLayers.HEX_COLORING_OWING_CIV then
     SetOwingCivHexes();
     UI.PlaySound("UI_Lens_Overlay_On");
@@ -681,17 +762,25 @@ end
 function OnLensLayerOff( layerNum:number )
   if (layerNum == LensLayers.HEX_COLORING_RELIGION or
       layerNum == LensLayers.HEX_COLORING_CONTINENT or
-      layerNum == LensLayers.HEX_COLORING_GOVERNMENT or
       layerNum == LensLayers.HEX_COLORING_OWING_CIV) then
     UI.PlaySound("UI_Lens_Overlay_Off");
+
+  -- Clear Modded Lens (Appeal lens included)
   elseif layerNum == LensLayers.HEX_COLORING_APPEAL_LEVEL then
-    -- Only clear the water lens if we're turning off lenses altogether, but not if switching to another modal lens (Turning on another modal lens clears it already).
-    -- For the modded lens
     UILens.ClearLayerHexes( LensLayers.MAP_HEX_MASK );
     if UI.GetInterfaceMode() ~= InterfaceModeTypes.VIEW_MODAL_LENS or (UI.GetHeadSelectedUnit() == nil) then
       UILens.ClearLayerHexes(LensLayers.HEX_COLORING_APPEAL_LEVEL);
     end
     UI.PlaySound("UI_Lens_Overlay_Off");
+
+  -- Clear Area Lens (Government lens included)
+  elseif layerNum == LensLayers.HEX_COLORING_GOVERNMENT then
+    UILens.ClearLayerHexes( LensLayers.MAP_HEX_MASK );
+    if UI.GetInterfaceMode() ~= InterfaceModeTypes.VIEW_MODAL_LENS or (UI.GetHeadSelectedUnit() == nil) then
+      UILens.ClearLayerHexes(LensLayers.HEX_COLORING_GOVERNMENT);
+    end
+    UI.PlaySound("UI_Lens_Overlay_Off");
+
   elseif layerNum == LensLayers.HEX_COLORING_WATER_AVAILABLITY then
     -- Only clear the water lens if we're turning off lenses altogether, but not if switching to another modal lens (Turning on another modal lens clears it already).
     if UI.GetInterfaceMode() ~= InterfaceModeTypes.VIEW_MODAL_LENS or (UI.GetHeadSelectedUnit() == nil) then
@@ -749,37 +838,138 @@ end
 
 -- ===========================================================================
 function SetWaterHexes()
-  local FullWaterPlots:table = {};
-  local CoastalWaterPlots:table = {};
-  local NoWaterPlots:table = {};
-  local NoSettlePlots:table = {};
+  if (not m_CtrlDown) or UI.GetInterfaceMode() == InterfaceModeTypes.VIEW_MODAL_LENS then
+    local FullWaterPlots:table = {};
+    local CoastalWaterPlots:table = {};
+    local NoWaterPlots:table = {};
+    local NoSettlePlots:table = {};
 
-  UILens.ClearLayerHexes(LensLayers.HEX_COLORING_WATER_AVAILABLITY);
-  FullWaterPlots, CoastalWaterPlots, NoWaterPlots, NoSettlePlots = Map.GetContinentPlotsWaterAvailability();
+    UILens.ClearLayerHexes(LensLayers.HEX_COLORING_WATER_AVAILABLITY);
+    FullWaterPlots, CoastalWaterPlots, NoWaterPlots, NoSettlePlots = Map.GetContinentPlotsWaterAvailability();
 
-  local BreathtakingColor :number = UI.GetColorValue("COLOR_BREATHTAKING_APPEAL");
-  local CharmingColor     :number = UI.GetColorValue("COLOR_CHARMING_APPEAL");
-  local AverageColor      :number = UI.GetColorValue("COLOR_AVERAGE_APPEAL");
-  local DisgustingColor   :number = UI.GetColorValue("COLOR_DISGUSTING_APPEAL");
-  local localPlayer       :number = Game.GetLocalPlayer();
+    local BreathtakingColor :number = UI.GetColorValue("COLOR_BREATHTAKING_APPEAL");
+    local CharmingColor     :number = UI.GetColorValue("COLOR_CHARMING_APPEAL");
+    local AverageColor      :number = UI.GetColorValue("COLOR_AVERAGE_APPEAL");
+    local DisgustingColor   :number = UI.GetColorValue("COLOR_DISGUSTING_APPEAL");
+    local localPlayer       :number = Game.GetLocalPlayer();
 
-  if(table.count(FullWaterPlots) > 0) then
-    UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_WATER_AVAILABLITY, localPlayer, FullWaterPlots, BreathtakingColor );
+    if(table.count(FullWaterPlots) > 0) then
+      UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_WATER_AVAILABLITY, localPlayer, FullWaterPlots, BreathtakingColor );
+    end
+    if(table.count(CoastalWaterPlots) > 0) then
+      UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_WATER_AVAILABLITY, localPlayer, CoastalWaterPlots, CharmingColor );
+    end
+    if(table.count(NoWaterPlots) > 0) then
+      UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_WATER_AVAILABLITY, localPlayer, NoWaterPlots, AverageColor );
+    end
+    if(table.count(NoSettlePlots) > 0) then
+      UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_WATER_AVAILABLITY, localPlayer, NoSettlePlots, DisgustingColor );
+    end
+
+  else -- A settler is selected with ctrl down, show alternate highlighting
+    SetSettlerLens()
   end
-  if(table.count(CoastalWaterPlots) > 0) then
-    UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_WATER_AVAILABLITY, localPlayer, CoastalWaterPlots, CharmingColor );
+end
+
+function SetSettlerLens()
+  -- If cursor is not on a plot, don't do anything
+  local plotId = UI.GetCursorPlotID();
+  if (not Map.IsPlot(plotId)) then
+    return
   end
-  if(table.count(NoWaterPlots) > 0) then
-    UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_WATER_AVAILABLITY, localPlayer, NoWaterPlots, AverageColor );
+
+  local pPlot = Map.GetPlotByIndex(plotId)
+  local localPlayer:number = Game.GetLocalPlayer();
+  local localPlayerVis:table = PlayersVisibility[localPlayer];
+  local localPlayerCities = Players[localPlayer]:GetCities()
+
+  local tNonDimPlots:table = {}
+  local tUnusablePlots:table = {}
+  local tOverlapPlots:table = {}
+  local tResourcePlots:table = {}
+  local tRegularPlots:table = {}
+
+  local iUnusableColor:number = UI.GetColorValue("COLOR_ALT_SETTLER_UNUSABLE");
+  local iOverlapColor:number = UI.GetColorValue("COLOR_ALT_SETTLER_OVERLAP");
+  local iResourceColor:number = UI.GetColorValue("COLOR_ALT_SETTLER_RESOURCE");
+  local iRegularColor:number = UI.GetColorValue("COLOR_ALT_SETTLER_REGULAR");
+
+  for pRangePlot in PlotAreaSpiralIterator(pPlot, CITY_WORK_RANGE,
+      SECTOR_NONE, DIRECTION_CLOCKWISE, DIRECTION_OUTWARDS, CENTRE_INCLUDE) do
+
+    local plotX = pRangePlot:GetX()
+    local plotY = pRangePlot:GetY()
+    local plotID = pRangePlot:GetIndex()
+    if localPlayerVis:IsRevealed(plotX, plotY) then
+
+      table.insert(tNonDimPlots, plotID)
+      if plotWithinWorkingRange(localPlayer, plotID) then
+        table.insert(tOverlapPlots, plotID)
+
+      elseif pRangePlot:IsImpassable() then
+        table.insert(tUnusablePlots, plotID)
+
+      elseif pRangePlot:IsOwned() and pRangePlot:GetOwner() ~= localPlayer then
+        table.insert(tUnusablePlots, plotID)
+
+      elseif plotHasResource(pRangePlot) and
+          playerHasDiscoveredResource(localPlayer, plotID) then
+
+        table.insert(tResourcePlots, plotID)
+      else
+        table.insert(tRegularPlots, plotID)
+      end
+    end
   end
-  if(table.count(NoSettlePlots) > 0) then
-    UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_WATER_AVAILABLITY, localPlayer, NoSettlePlots, DisgustingColor );
+
+  -- Alt_HighlightPlots(tNonDimPlots)
+
+  if #tOverlapPlots > 0 then
+    UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_WATER_AVAILABLITY, localPlayer, tOverlapPlots, iOverlapColor );
   end
+
+  if #tUnusablePlots > 0 then
+    UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_WATER_AVAILABLITY, localPlayer, tUnusablePlots, iUnusableColor );
+  end
+
+  if #tResourcePlots > 0 then
+    UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_WATER_AVAILABLITY, localPlayer, tResourcePlots, iResourceColor );
+  end
+
+  if #tRegularPlots  > 0 then
+    UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_WATER_AVAILABLITY, localPlayer, tRegularPlots, iRegularColor );
+  end
+end
+
+function RefreshSettlerLens()
+  ClearSettlerLens()
+  UILens.ToggleLayerOn( LensLayers.HEX_COLORING_WATER_AVAILABLITY );
+end
+
+function ClearSettlerLens()
+  -- Alt_ClearHighlightedPlots()
+
+  if UILens.IsLayerOn( LensLayers.HEX_COLORING_WATER_AVAILABLITY ) then
+    UILens.ToggleLayerOff( LensLayers.HEX_COLORING_WATER_AVAILABLITY );
+  end
+end
+
+-- Checks to see if settler lens should be reapplied
+function RecheckSettlerLens()
+  local selectedUnit = UI.GetHeadSelectedUnit()
+  if (selectedUnit ~= nil) then
+    local unitType = GetUnitType(selectedUnit:GetOwner(), selectedUnit:GetID());
+    if (unitType == "UNIT_SETTLER") then
+      RefreshSettlerLens()
+      return
+    end
+  end
+
+  ClearSettlerLens()
 end
 
 -- ===========================================================================
 function SetGovernmentHexes()
-  -- print("Setting government lens")
   local localPlayer : number = Game.GetLocalPlayer();
   local localPlayerVis:table = PlayersVisibility[localPlayer];
   if (localPlayerVis ~= nil) then
@@ -789,27 +979,28 @@ function SetGovernmentHexes()
       local culture = player:GetCulture();
       local governmentId :number = culture:GetCurrentGovernment();
       local GovernmentColor;
-      if(governmentId < 0) or GameInfo.Governments[governmentId] == nil then
-        GovernmentColor = UI.GetColorValue("COLOR_GOVERNMENT_CITYSTATE");
-        -- print("COLOR_GOVERNMENT_CITYSTATE")
-      else
-        GovernmentColor = UI.GetColorValue("COLOR_" ..  GameInfo.Governments[governmentId].GovernmentType);
-        -- print("COLOR_" ..  GameInfo.Governments[governmentId].GovernmentType)
-      end
 
-      -- print(GovernmentColor)
+      if culture:IsInAnarchy() then
+        GovernmentColor = UI.GetColorValue("COLOR_CLEAR");
+      else
+        if(governmentId < 0) then
+          GovernmentColor = UI.GetColorValue("COLOR_GOVERNMENT_CITYSTATE");
+        else
+          GovernmentColor = UI.GetColorValue("COLOR_" ..  GameInfo.Governments[governmentId].GovernmentType);
+        end
+      end
 
       for _, pCity in cities:Members() do
         local visibleCityPlots:table = Map.GetCityPlots():GetVisiblePurchasedPlots(pCity);
 
-        if table.count(visibleCityPlots) > 0 then
+        if(table.count(visibleCityPlots) > 0) then
           UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_GOVERNMENT, localPlayer, visibleCityPlots, GovernmentColor );
         end
       end
-
-      -- return
     end
   end
+
+  m_FullClearAreaLens = true;
 end
 
 -- ===========================================================================
@@ -901,6 +1092,11 @@ function SetBuilderLensHexes()
       if pPlot:IsImpassable() then
         table.insert(unworkableHexes, i)
 
+      -- NATIONAL PARK
+      --------------------------------------
+      elseif pPlot:IsNationalPark() then
+        table.insert(unworkableHexes, i)
+
       -- IMPROVEMENTS
       --------------------------------------
       elseif plotHasImprovement(pPlot) then
@@ -951,15 +1147,6 @@ function SetBuilderLensHexes()
           table.insert(unworkableHexes, i);
         end
 
-      -- HILL
-      --------------------------------------
-      elseif plotHasHill(pPlot) then
-        if plotNextToBuffingWonder(pPlot) then
-          table.insert(recomFeatureHexes, i)
-        else
-          table.insert(hillHexes, i);
-        end
-
       -- FEATURE - Note: This includes natural wonders, since wonder is also a "feature". Check Features.xml
       --------------------------------------
       elseif plotHasFeature(pPlot) then
@@ -973,12 +1160,21 @@ function SetBuilderLensHexes()
           table.insert(unworkableHexes, i)
         end
 
+      -- HILL - MINE
+      --------------------------------------
+      elseif plotHasImprovableHill(pPlot) then
+        if plotNextToBuffingWonder(pPlot) then
+          table.insert(recomFeatureHexes, i)
+        else
+          table.insert(hillHexes, i);
+        end
+
       -- GENERIC TILE
       --------------------------------------
       elseif plotCanHaveImprovement(localPlayer, i) then
         if plotNextToBuffingWonder(pPlot) then
           table.insert(recomFeatureHexes, i)
-        else
+        elseif plotCanHaveFarm(plot) then
           table.insert(genericHexes, i)
         end
 
@@ -1016,17 +1212,9 @@ function SetBuilderLensHexes()
   if table.count(genericHexes) > 0 then
     UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_APPEAL_LEVEL, localPlayer, genericHexes, GenericColor );
   end
-  if table.count(unworkableHexes) > 0 then
+  if SHOW_NOTHING_TODO_IN_BUILDER_LENS and table.count(unworkableHexes) > 0 then
     UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_APPEAL_LEVEL, localPlayer, unworkableHexes, NothingColor );
   end
-end
-
-function ClearModdedLens()
-  UILens.ClearLayerHexes( LensLayers.MAP_HEX_MASK );
-  if UILens.IsLayerOn( LensLayers.HEX_COLORING_APPEAL_LEVEL ) then
-    UILens.ToggleLayerOff( LensLayers.HEX_COLORING_APPEAL_LEVEL );
-  end
-  SetActiveModdedLens(MODDED_LENS_ID.NONE);
 end
 
 function ClearBuilderLensHexes()
@@ -1094,7 +1282,7 @@ function ShowArchaeologistLens()
 end
 
 -- ===========================================================================
-function SetCityOverlapLens(range)
+function SetCityOverlapLens()
   -- print("Show City Overlap 6 lens")
   local mapWidth, mapHeight = Map.GetGridSize();
   local localPlayer   :number = Game.GetLocalPlayer();
@@ -1102,21 +1290,17 @@ function SetCityOverlapLens(range)
 
   local plotEntries       :table = {};
   local numCityEntries    :table = {};
+  local localPlayerCities = Players[localPlayer]:GetCities()
 
   for i = 0, (mapWidth * mapHeight) - 1, 1 do
     local pPlot:table = Map.GetPlotByIndex(i);
 
     if localPlayerVis:IsRevealed(pPlot:GetX(), pPlot:GetY()) then
-      -- if pPlot:GetOwner() == localPlayer then
+      if pPlot:GetOwner() == localPlayer or Controls.ShowLensOutsideBorder:IsChecked() then
         local numCities = 0;
-        -- get cities that in range of this hex.
-        local localPlayerCities = Players[localPlayer]:GetCities()
-        for i, pCity in localPlayerCities:Members() do
-          if pCity ~= nil and pCity:GetOwner() == localPlayer then
-            local pCityPlot = Map.GetPlot(pCity:GetX(), pCity:GetY())
-            if Map.GetPlotDistance(pPlot:GetX(), pPlot:GetY(), pCityPlot:GetX(), pCityPlot:GetY()) <= range then
+        for _, pCity in localPlayerCities:Members() do
+          if Map.GetPlotDistance(pPlot:GetX(), pPlot:GetY(), pCity:GetX(), pCity:GetY()) <= m_CityOverlapRange then
               numCities = numCities + 1;
-            end
           end
         end
 
@@ -1126,7 +1310,7 @@ function SetCityOverlapLens(range)
           table.insert(plotEntries, i);
           table.insert(numCityEntries, numCities);
         end
-      -- end
+      end
     end
   end
 
@@ -1140,6 +1324,64 @@ function SetCityOverlapLens(range)
     local color:number = UI.GetColorValue(colorLookup);
     UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_APPEAL_LEVEL, localPlayer, {plotEntries[i]}, color );
   end
+end
+
+function Alt_SetCityOverlapLens()
+  local plotId = UI.GetCursorPlotID();
+  if (not Map.IsPlot(plotId)) then
+    return;
+  end
+
+  local pPlot = Map.GetPlotByIndex(plotId)
+  local localPlayer = Game.GetLocalPlayer()
+  local localPlayerVis:table = PlayersVisibility[localPlayer]
+  local cityPlots:table = {}
+  local normalPlot:table = {}
+
+  for pAdjacencyPlot in PlotAreaSpiralIterator(pPlot, m_CityOverlapRange, SECTOR_NONE, DIRECTION_CLOCKWISE, DIRECTION_OUTWARDS, CENTRE_INCLUDE) do
+    if localPlayerVis:IsRevealed(pAdjacencyPlot:GetX(), pAdjacencyPlot:GetY()) then
+      if (pAdjacencyPlot:GetOwner() == localPlayer and pAdjacencyPlot:IsCity()) then
+        table.insert(cityPlots, pAdjacencyPlot:GetIndex());
+      else
+        table.insert(normalPlot, pAdjacencyPlot:GetIndex());
+      end
+    end
+  end
+
+  if (table.count(cityPlots) > 0) then
+    local plotColor:number = UI.GetColorValue("COLOR_GRADIENT8_1");
+    UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_APPEAL_LEVEL, localPlayer, cityPlots, plotColor );
+  end
+
+  if (table.count(normalPlot) > 0) then
+    local plotColor:number = UI.GetColorValue("COLOR_GRADIENT8_3");
+    UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_APPEAL_LEVEL, localPlayer, normalPlot, plotColor );
+  end
+end
+
+function RefreshCityOverlapLens()
+  -- Assuming City Overlap lens is already applied
+  UILens.ClearLayerHexes(LensLayers.HEX_COLORING_APPEAL_LEVEL);
+  SetCityOverlapLens();
+end
+
+function Refresh_AltCityOverlapLens()
+  UILens.ClearLayerHexes(LensLayers.HEX_COLORING_APPEAL_LEVEL);
+  Alt_SetCityOverlapLens();
+end
+
+function IncreseOverlapRange()
+  m_CityOverlapRange = m_CityOverlapRange + 1;
+  Controls.OverlapRangeLabel:SetText(m_CityOverlapRange);
+  RefreshCityOverlapLens();
+end
+
+function DecreaseOverlapRange()
+  if (m_CityOverlapRange > 0) then
+    m_CityOverlapRange = m_CityOverlapRange - 1;
+  end
+  Controls.OverlapRangeLabel:SetText(m_CityOverlapRange);
+  RefreshCityOverlapLens();
 end
 
 -- ===========================================================================
@@ -1214,29 +1456,24 @@ function SetResourceLens()
         if resourceInfo ~= nil then
 
           -- Check if resource is not in exclusion list
-          local resourceToExclude:boolean = false;
-          for i, rType in ipairs(ResourceExclusionList) do
-            if resourceInfo.ResourceType == rType then
-              resourceToExclude = true;
-              break
-            end
-          end
-
-          if not resourceToExclude then
+          if not has_value(ResourceExclusionList, resourceInfo.ResourceType) and (not has_value(ResourcesToHide, resourceInfo.ResourceType)) then
             table.insert(ResourcePlots, i);
-            if resourceInfo.ResourceClassType == "RESOURCECLASS_BONUS" then
+            if resourceInfo.ResourceClassType == "RESOURCECLASS_BONUS" and
+                not has_value(ResourceCategoryToHide, "Bonus") then
               if plotHasImprovement(pPlot) and not pPlot:IsImprovementPillaged() then
                 table.insert(ConnectedBonus, i)
               else
                 table.insert(NotConnectedBonus, i)
               end
-            elseif resourceInfo.ResourceClassType == "RESOURCECLASS_LUXURY" then
+            elseif resourceInfo.ResourceClassType == "RESOURCECLASS_LUXURY" and
+                not has_value(ResourceCategoryToHide, "Luxury") then
               if plotHasImprovement(pPlot) and not pPlot:IsImprovementPillaged() then
                 table.insert(ConnectedLuxury, i)
               else
                 table.insert(NotConnectedLuxury, i)
               end
-            elseif resourceInfo.ResourceClassType == "RESOURCECLASS_STRATEGIC" then
+            elseif resourceInfo.ResourceClassType == "RESOURCECLASS_STRATEGIC" and
+                not has_value(ResourceCategoryToHide, "Strategic") then
               if plotHasImprovement(pPlot) and not pPlot:IsImprovementPillaged() then
                 table.insert(ConnectedStrategic, i)
               else
@@ -1272,6 +1509,179 @@ function SetResourceLens()
   if table.count(NotConnectedBonus) > 0 then
     UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_APPEAL_LEVEL, localPlayer, NotConnectedBonus, BonusNConnectedColor );
   end
+end
+
+function RefreshResourcePicker()
+  print("Show Resource Picker")
+  local mapWidth, mapHeight = Map.GetGridSize();
+  local localPlayer   :number = Game.GetLocalPlayer();
+  local localPlayerVis:table = PlayersVisibility[localPlayer];
+
+  -- Resources to exclude in the "Resource Lens"
+  local ResourceExclusionList:table = {
+    "RESOURCE_ANTIQUITY_SITE",
+    "RESOURCE_SHIPWRECK"
+  }
+
+  local BonusResources:table = {}
+  local LuxuryResources:table = {}
+  local StrategicResources:table = {}
+
+  for i = 0, (mapWidth * mapHeight) - 1, 1 do
+    local pPlot:table = Map.GetPlotByIndex(i);
+
+    if localPlayerVis:IsRevealed(pPlot:GetX(), pPlot:GetY()) and playerHasDiscoveredResource(localPlayer, i) then
+      local resourceType = pPlot:GetResourceType()
+      if resourceType ~= nil and resourceType >= 0 then
+        local resourceInfo = GameInfo.Resources[resourceType];
+        if resourceInfo ~= nil then
+          -- Check if resource is not in exclusion list
+          if not has_value(ResourceExclusionList, resourceInfo.ResourceType) then
+            if resourceInfo.ResourceClassType == "RESOURCECLASS_BONUS" then
+              if not has_rInfo(BonusResources, resourceInfo.ResourceType) then
+                table.insert(BonusResources, resourceInfo)
+              end
+            elseif resourceInfo.ResourceClassType == "RESOURCECLASS_LUXURY" then
+              if not has_rInfo(LuxuryResources, resourceInfo.ResourceType) then
+                table.insert(LuxuryResources, resourceInfo)
+              end
+            elseif resourceInfo.ResourceClassType == "RESOURCECLASS_STRATEGIC" then
+              if not has_rInfo(StrategicResources, resourceInfo.ResourceType) then
+                table.insert(StrategicResources, resourceInfo)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  Controls.BonusResourcePickStack:DestroyAllChildren();
+  Controls.LuxuryResourcePickStack:DestroyAllChildren();
+  Controls.StrategicResourcePickStack:DestroyAllChildren();
+
+  -- Bonus Resources
+  if table.count(BonusResources) > 0 and
+      not has_value(ResourceCategoryToHide, "Bonus") then
+    for i, resourceInfo in ipairs(BonusResources) do
+      -- print(Locale.Lookup(resourceInfo.Name))
+      local resourcePickInstance:table = {};
+      ContextPtr:BuildInstanceForControl( "ResourcePickEntry", resourcePickInstance, Controls.BonusResourcePickStack );
+      resourcePickInstance.ResourceLabel:SetText("[ICON_" .. resourceInfo.ResourceType .. "]" .. Locale.Lookup(resourceInfo.Name));
+
+      if has_value(ResourcesToHide, resourceInfo.ResourceType) then
+        resourcePickInstance.ResourceCheckbox:SetCheck(false);
+      end
+
+      resourcePickInstance.ResourceCheckbox:RegisterCallback(Mouse.eLClick, function() HandleResourceCheckbox(resourcePickInstance, resourceInfo.ResourceType); end);
+    end
+  end
+
+  -- Luxury Resources
+  if table.count(LuxuryResources) > 0 and
+      not has_value(ResourceCategoryToHide, "Luxury") then
+    for i, resourceInfo in ipairs(LuxuryResources) do
+      -- print(Locale.Lookup(resourceInfo.Name))
+      local resourcePickInstance:table = {};
+      ContextPtr:BuildInstanceForControl( "ResourcePickEntry", resourcePickInstance, Controls.LuxuryResourcePickStack );
+      resourcePickInstance.ResourceLabel:SetText("[ICON_" .. resourceInfo.ResourceType .. "]" .. Locale.Lookup(resourceInfo.Name));
+
+      if has_value(ResourcesToHide, resourceInfo.ResourceType) then
+        resourcePickInstance.ResourceCheckbox:SetCheck(false);
+      end
+
+      resourcePickInstance.ResourceCheckbox:RegisterCallback(Mouse.eLClick, function() HandleResourceCheckbox(resourcePickInstance, resourceInfo.ResourceType); end);
+    end
+  end
+
+  -- Strategic Resources
+  if table.count(StrategicResources) > 0 and
+      not has_value(ResourceCategoryToHide, "Strategic") then
+    for i, resourceInfo in ipairs(StrategicResources) do
+      -- print(Locale.Lookup(resourceInfo.Name))
+      local resourcePickInstance:table = {};
+      ContextPtr:BuildInstanceForControl( "ResourcePickEntry", resourcePickInstance, Controls.StrategicResourcePickStack );
+      resourcePickInstance.ResourceLabel:SetText("[ICON_" .. resourceInfo.ResourceType .. "]" .. Locale.Lookup(resourceInfo.Name));
+
+      if has_value(ResourcesToHide, resourceInfo.ResourceType) then
+        resourcePickInstance.ResourceCheckbox:SetCheck(false);
+      end
+
+      resourcePickInstance.ResourceCheckbox:RegisterCallback(Mouse.eLClick, function() HandleResourceCheckbox(resourcePickInstance, resourceInfo.ResourceType); end);
+    end
+  end
+
+  -- Cleanup
+  Controls.BonusResourcePickStack:CalculateSize();
+  Controls.LuxuryResourcePickStack:CalculateSize();
+  Controls.StrategicResourcePickStack:CalculateSize();
+  Controls.ResourcePickList:CalculateSize();
+end
+
+function ToggleResourceLens_Bonus()
+  if not Controls.ShowBonusResource:IsChecked() then
+    print("Hide Bonus Resource")
+    ndup_insert(ResourceCategoryToHide, "Bonus")
+  else
+    print("Show Bonus Resource")
+    find_and_remove(ResourceCategoryToHide, "Bonus");
+  end
+
+  -- Assuming resource lens is already applied
+  UILens.ClearLayerHexes(LensLayers.HEX_COLORING_APPEAL_LEVEL);
+  RefreshResourcePicker();
+  SetResourceLens();
+end
+
+function ToggleResourceLens_Luxury()
+  if not Controls.ShowLuxuryResource:IsChecked() then
+    print("Hide Luxury Resource")
+    ndup_insert(ResourceCategoryToHide, "Luxury")
+  else
+    print("Show Luxury Resource")
+    find_and_remove(ResourceCategoryToHide, "Luxury");
+  end
+
+  -- Assuming resource lens is already applied
+  UILens.ClearLayerHexes(LensLayers.HEX_COLORING_APPEAL_LEVEL);
+  RefreshResourcePicker();
+  SetResourceLens();
+end
+
+function ToggleResourceLens_Strategic()
+  if not Controls.ShowStrategicResource:IsChecked() then
+    print("Hide Strategic Resource")
+    ndup_insert(ResourceCategoryToHide, "Strategic")
+  else
+    print("Show Strategic Resource")
+    find_and_remove(ResourceCategoryToHide, "Strategic");
+  end
+
+  -- Assuming resource lens is already applied
+  UILens.ClearLayerHexes(LensLayers.HEX_COLORING_APPEAL_LEVEL);
+  RefreshResourcePicker();
+  SetResourceLens();
+end
+
+function HandleResourceCheckbox(pControl, resourceType)
+  if not pControl.ResourceCheckbox:IsChecked() then
+    -- Don't show this resource
+    if not has_value(ResourcesToHide, resourceType) then
+      table.insert(ResourcesToHide, resourceType)
+    end
+  else
+    -- Show this resource
+    for i, rType in ipairs(ResourcesToHide) do
+      if rType == resourceType then
+        table.remove(ResourcesToHide, i)
+        break
+      end
+    end
+  end
+
+  -- Assuming resource lens is already applied
+  UILens.ClearLayerHexes(LensLayers.HEX_COLORING_APPEAL_LEVEL);
+  SetResourceLens();
 end
 
 -- ===========================================================================
@@ -1406,19 +1816,370 @@ function ClearScoutLens()
   ClearModdedLens();
 end
 
--- Called when a archeologist is selected
+-- Called when a scout is selected
 function ShowScoutLens()
   SetActiveModdedLens(MODDED_LENS_ID.SCOUT);
   UILens.ToggleLayerOn(LensLayers.HEX_COLORING_APPEAL_LEVEL);
 end
 
--- Helper functions ===========================================================
+-- ===========================================================================
+function SetNaturalistLens()
+  print("Show Naturalist lens")
+  local localPlayer:number = Game.GetLocalPlayer();
+  local localPlayerVis:table = PlayersVisibility[localPlayer];
+
+  local parkPlotColor:number = UI.GetColorValue("COLOR_PARK_NATURALIST_LENS");
+  local OkColor:number = UI.GetColorValue("COLOR_OK_NATURALIST_LENS");
+  local FixableColor:number = UI.GetColorValue("COLOR_FIXABLE_NATURALIST_LENS");
+
+  local fixableHexes:table = {};
+  local okHexes:table = {};
+  local tiles:table = {};
+
+  -- Get plots that can be made into National Parks without any changes
+  local rawParkPlots:table = Game.GetNationalParks():GetPossibleParkTiles(localPlayer);
+
+  -- Collect individual tile data
+  local mapWidth, mapHeight = Map.GetGridSize();
+  for plotIndex = 0, (mapWidth * mapHeight) - 1, 1 do
+    local pPlot:table = Map.GetPlotByIndex(plotIndex);
+    if localPlayerVis:IsRevealed(pPlot:GetX(), pPlot:GetY()) then
+      local data =  {
+        X     = pPlot:GetX();
+        Y     = pPlot:GetY();
+        Level = 0;
+        Cities = nil;
+        Use   = false;
+      };
+
+      -- Level 3 = OK
+      -- Level 2 = Fixable
+      -- Level 1 = Semifixable
+
+      -- Base requirements
+      if plotHasNaturalWonder(pPlot) then
+        data.Level = 3;
+
+      elseif pPlot:IsMountain() then
+        data.Level = 3;
+
+      -- Appeal charming or better
+      elseif pPlot:GetAppeal() >= 2 then
+        data.Level = 3;
+
+      -- Check for fixable plots by doing something to increase appeal
+      elseif pPlot:GetAppeal() >= 1 then
+        -- Removable unappealing feature
+        local featureInfo = GameInfo.Features[pPlot:GetFeatureType()]
+        if featureInfo ~= nil then
+          local featureType = featureInfo.FeatureType
+          if featureType == "FEATURE_JUNGLE" or featureType == "FEATURE_MARSH" then
+            data.Level = 2;
+          end
+        end
+
+        -- TODO - Check for plantable forest?
+      end
+
+      -- An improvement can be removed, downgrade to fixable
+      if data.Level > 2 and plotHasImprovement(pPlot) then
+        data.Level = 2;
+      end
+
+      -- If not owned by any player
+      if pPlot:GetOwner() ~= Game.GetLocalPlayer() then
+        if data.Level > 2 then
+          data.Level = 2;
+        end
+      end
+
+      -- Blocking changes
+      if plotHasWonder(pPlot) then
+        data.Level = 0;
+      elseif plotHasDistrict(pPlot) then -- also checks for cities (city district)
+        data.Level = 0;
+      elseif pPlot:IsNationalPark() then
+        data.Level = 0;
+      end
+
+      -- Only keep relevant tiles and those that have cities in range
+      if data.Level > 0 then
+        data.Cities = GetCitiesWithinWorkingRange(localPlayer, plotIndex)
+        if table.count(data.Cities) > 0 then
+          -- print(plotIndex, unpack(data.Cities))
+          tiles[plotIndex] = data;
+        end
+      end
+    end
+  end
+
+  -- Mark those that are interesting
+  -- They must belong to a diamond where all four are at least semifixable.
+  for i1, data in pairs(tiles) do
+    -- Get the four plots for the vertical diamond
+    local p1:table = Map.GetPlot(data.X, data.Y)
+    local p2:table = Map.GetPlot(data.X + data.Y % 2 - 1, data.Y + 1);
+    local p3:table = Map.GetPlot(data.X + data.Y % 2, data.Y + 1);
+    local p4:table = Map.GetPlot(data.X, data.Y + 2);
+
+    -- All four must exist
+    if p1 ~= nil and p2 ~= nil and p3 ~= nil and p4 ~= nil then
+      local i2 = p2:GetIndex();
+      local i3 = p3:GetIndex();
+      local i4 = p4:GetIndex();
+      -- All three calculated diamond plots should have data
+      if tiles[i2] ~= nil and tiles[i3] ~= nil and tiles[i4] ~= nil then
+
+        -- Make sure the four plots have some common city in range
+        local commonCities12 = get_common_values(tiles[i1].Cities, tiles[i2].Cities)
+        local commonCities34 = get_common_values(tiles[i3].Cities, tiles[i4].Cities)
+        local netCommonCities = get_common_values(commonCities12, commonCities34)
+
+        if table.count(netCommonCities) > 0 then
+          -- Use these plots only if they passable
+          if not tiles[i1].Use and not p1:IsImpassable() then
+            tiles[i1].Use = true;
+          end
+          if not tiles[i2].Use and not p2:IsImpassable() then
+            tiles[i2].Use = true;
+          end
+          if not tiles[i3].Use and not p3:IsImpassable() then
+            tiles[i3].Use = true;
+          end
+          if not tiles[i4].Use and not p4:IsImpassable() then
+            tiles[i4].Use = true;
+          end
+        end
+      end
+    end
+  end
+
+  -- Extract info. Don't use plots that exist in rawParkPlots
+  for i, data in pairs(tiles) do
+    if tiles[i].Use and not has_value(rawParkPlots, i) then
+      if tiles[i].Level == 3 then
+        -- print("ok", i)
+        table.insert(okHexes, i)
+      elseif tiles[i].Level == 2 then
+        -- print("fix", i)
+        table.insert(fixableHexes, i)
+      end
+    end
+  end
+
+  if table.count(fixableHexes) > 0 then
+    UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_APPEAL_LEVEL, localPlayer, fixableHexes, FixableColor );
+  end
+  if table.count(okHexes) > 0 then
+    UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_APPEAL_LEVEL, localPlayer, okHexes, OkColor );
+  end
+  if table.count(rawParkPlots) > 0 then
+    UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_APPEAL_LEVEL, localPlayer, rawParkPlots, parkPlotColor );
+  end
+end
+
+-- Returns a table of cities that are within working range of the plot
+function  GetCitiesWithinWorkingRange(playerID:number, plotIndex:number)
+  local localPlayerCities = Players[playerID]:GetCities()
+  local pPlot = Map.GetPlotByIndex(plotIndex)
+  local plotX = pPlot:GetX()
+  local plotY = pPlot:GetY()
+
+  local tCities = {}
+  for _, pCity in localPlayerCities:Members() do
+    if Map.GetPlotDistance(plotX, plotY, pCity:GetX(), pCity:GetY()) <= CITY_WORK_RANGE then
+      table.insert(tCities, pCity:GetID())
+    end
+  end
+  return tCities
+end
+
+-- ===========================================================================
+function ShowCitizenManagementArea(cityID)
+  SetActiveAreaLens(AREA_LENS_ID.CITIZEN_MANAGEMENT)
+  UILens.ToggleLayerOn(LensLayers.HEX_COLORING_GOVERNMENT)
+
+  local pCity:table;
+  local localPlayer = Game.GetLocalPlayer()
+
+  if (cityID ~= nil) then
+    pCity = Players[localPlayer]:GetCities():FindID(cityID);
+  else
+    local pPlot = Map.GetPlotByIndex(m_CurrentCursorPlotID)
+    if pPlot:IsCity() and pPlot:GetOwner() == Game.GetLocalPlayer() then
+      pCity = CityManager.GetCityAt(pPlot:GetX(), pPlot:GetY());
+    end
+  end
+
+  if pCity ~= nil then
+    print("Show citizens for " .. Locale.Lookup(pCity:GetName()))
+    m_tAreaPlotsColored = {}
+
+    local tParameters:table = {};
+    local cityPlotID = Map.GetPlot(pCity:GetX(), pCity:GetY()):GetIndex()
+    tParameters[CityCommandTypes.PARAM_MANAGE_CITIZEN] = UI.GetInterfaceModeParameter(CityCommandTypes.PARAM_MANAGE_CITIZEN);
+
+    local tWorkingPlots:table = {}  -- Plots worked by unlocked citizens
+    local tLockedPlots:table = {}   -- Plots worked by locked citizes
+
+    -- Get city plot and citizens info
+    local tResults:table = CityManager.GetCommandTargets(pCity, CityCommandTypes.MANAGE, tParameters);
+    if tResults == nil then
+      print("Could not find plots")
+      return
+    end
+
+    local tPlots:table = tResults[CityCommandResults.PLOTS];
+    local tUnits:table = tResults[CityCommandResults.CITIZENS];
+    local tLockedUnits:table = tResults[CityCommandResults.LOCKED_CITIZENS];
+
+    if tPlots ~= nil then
+      for i, plotID in ipairs(tPlots) do
+        table.insert(m_tAreaPlotsColored, plotID);
+        if (tLockedUnits[i] > 0 or cityPlotID == plotID) then
+          table.insert(tLockedPlots, plotID);
+        elseif (tUnits[i] > 0) then
+          table.insert(tWorkingPlots, plotID);
+        end
+      end
+    end
+
+    local workingColor:number = UI.GetColorValue("COLOR_CITY_PLOT_WORKING");
+    local lockedColor:number = UI.GetColorValue("COLOR_CITY_PLOT_LOCKED");
+
+    if #tWorkingPlots > 0 then
+      UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_GOVERNMENT, localPlayer, tWorkingPlots, workingColor );
+    end
+
+    if #tLockedPlots > 0 then
+      UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_GOVERNMENT, localPlayer, tLockedPlots, lockedColor );
+    end
+
+    m_CitizenManagementOn = true;
+  end
+end
+
+function RefreshCitizenManagementArea(cityID)
+  ClearAreaLens();
+  ShowCitizenManagementArea(cityID);
+end
+
+-- ===========================================================================
+function SetCustomLens()
+  local localPlayer = Game.GetLocalPlayer()
+  for i, plot_color in ipairs(m_CustomLens_PlotsAndColors) do
+    -- print(i .. " layer")
+    local color:number = plot_color.Color;
+    local plots:table = plot_color.Plots;
+
+    if table.count(plots) > 0 then
+      -- print("Apply Lens")
+      -- dump(plots)
+      UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_APPEAL_LEVEL, localPlayer, plots, color );
+    end
+  end
+end
+
+function ApplyCustomLens(plot_color_table)
+  SetActiveModdedLens(MODDED_LENS_ID.CUSTOM);
+
+  -- Check if the appeal lens is already active
+  if UILens.IsLayerOn(LensLayers.HEX_COLORING_APPEAL_LEVEL) then
+    -- Unapply the appeal lens, so it can be cleared from the screen
+    UILens.ToggleLayerOff(LensLayers.HEX_COLORING_APPEAL_LEVEL);
+  end
+
+  UILens.ToggleLayerOn(LensLayers.HEX_COLORING_APPEAL_LEVEL);
+
+  m_CustomLens_PlotsAndColors = plot_color_table
+end
+
+function ClearCustomLens()
+  ClearModdedLens();
+
+  if UI.GetInterfaceMode() == InterfaceModeTypes.VIEW_MODAL_LENS then
+    UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
+  end
+end
+
+-- ===========================================================================
+function OnApplyModdedLens(moddedLensID, showModalPanel:boolean)
+  if showModalPanel then
+    SetActiveModdedLens(moddedLensID);
+
+    -- Check if the appeal lens is already active
+    if UILens.IsLayerOn(LensLayers.HEX_COLORING_APPEAL_LEVEL) then
+      -- Unapply the appeal lens, so it can be cleared from the screen
+      UILens.SetActive("Default");
+    end
+
+    UILens.SetActive("Appeal");
+
+    RefreshInterfaceMode();
+  else
+    SetActiveModdedLens(moddedLensID);
+    UI.ToggleLayerOn(LensLayers.HEX_COLORING_APPEAL_LEVEL)
+  end
+end
+
+function OnClearModdedLens(showedModalPanel:boolean)
+  ClearModdedLens()
+
+  if showedModalPanel and UI.GetInterfaceMode() == InterfaceModeTypes.VIEW_MODAL_LENS then
+    UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
+  end
+end
+
+-- Modded lens helper functions ===========================================================
+function ClearModdedLens()
+  UILens.ClearLayerHexes( LensLayers.MAP_HEX_MASK );
+  if UILens.IsLayerOn( LensLayers.HEX_COLORING_APPEAL_LEVEL ) then
+    UILens.ToggleLayerOff( LensLayers.HEX_COLORING_APPEAL_LEVEL );
+  end
+  SetActiveModdedLens(MODDED_LENS_ID.NONE);
+end
+
+function ClearAreaLens()
+  print("Clearing area lens")
+
+  -- Because of engine limitations, clear previous color of tiles
+  local neutralColor:number = UI.GetColorValue("COLOR_AREA_LENS_NEUTRAL");
+  local localPlayer:number = Game.GetLocalPlayer();
+
+  if m_FullClearAreaLens then
+    local players = Game.GetPlayers();
+    for _, player in ipairs(players) do
+      local cities = player:GetCities();
+      for _, pCity in cities:Members() do
+        local visibleCityPlots:table = Map.GetCityPlots():GetVisiblePurchasedPlots(pCity);
+        if #visibleCityPlots > 0 then
+          UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_GOVERNMENT, localPlayer, visibleCityPlots, neutralColor );
+        end
+      end
+    end
+  elseif (table.count(m_tAreaPlotsColored) > 0) then
+    UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_GOVERNMENT, localPlayer, m_tAreaPlotsColored, neutralColor );
+    m_tAreaPlotsColored = {}
+  end
+
+  -- UILens.ClearLayerHexes( LensLayers.MAP_HEX_MASK );
+  if UILens.IsLayerOn( LensLayers.HEX_COLORING_GOVERNMENT ) then
+    UILens.ToggleLayerOff( LensLayers.HEX_COLORING_GOVERNMENT );
+  end
+
+  SetActiveAreaLens(MODDED_LENS_ID.NONE);
+
+  m_FullClearAreaLens = false;
+end
+
 function SetActiveModdedLens(lensID)
   m_CurrentModdedLensOn = lensID;
   LuaEvents.MinimapPanel_ModdedLensOn(lensID);
-  -- local dataDump = DataDumper(m_CurrentModdedLensOn, "currentModdedLensOn", true);
-  -- print("Set: " .. dataDump);
-  -- PlayerConfigurations[Game.GetLocalPlayer()]:SetValue("ModdedLens_CurrentModdedLensOn", dataDump);
+end
+
+function SetActiveAreaLens(lensID)
+  m_CurrentAreaLensOn = lensID;
+  LuaEvents.MinimapPanel_AreaLensOn(lensID);
 end
 
 function Alt_HighlightPlots(plotIndices)
@@ -1433,17 +2194,81 @@ function Alt_ClearHighlightedPlots()
   -- UILens.ToggleLayerOff(LensLayers.HEX_COLORING_ATTACK);
 end
 
-function GetCurrentModdedLens()
-  -- local localPlayerID = Game.GetLocalPlayer();
-  -- if(PlayerConfigurations[localPlayerID]:GetValue("ModdedLens_CurrentModdedLensOn") ~= nil) then
-  --  local dataDump = PlayerConfigurations[localPlayerID]:GetValue("ModdedLens_CurrentModdedLensOn");
-  -- print("Get: " .. dataDump);
-  --  loadstring(dataDump)();
-  --  m_CurrentModdedLensOn = currentModdedLensOn;
-  -- else
-  -- print("No modded lens data was found.")
-  -- end
-  return m_CurrentModdedLensOn;
+function HandleMouseForModdedLens( mousex:number, mousey:number )
+  -- Don't do anything if mouse is dragging
+  if not m_isMouseDragging then
+    -- Get plot under cursor
+    local plotId = UI.GetCursorPlotID();
+    if (not Map.IsPlot(plotId)) then
+      return;
+    end
+
+    -- If the cursor plot has not changed don't refresh
+    if (m_CurrentCursorPlotID == plotId) then
+      return
+    end
+
+    m_CurrentCursorPlotID = plotId
+
+    local pPlot = Map.GetPlotByIndex(m_CurrentCursorPlotID)
+    local selectedCity = UI.GetHeadSelectedCity()
+    local selectedUnit = UI.GetHeadSelectedUnit()
+
+    -- Handler for City Overlap lens
+    if (m_CurrentModdedLensOn == MODDED_LENS_ID.CITY_OVERLAP) then
+      if (Controls.OverlapLensMouseRange:IsChecked()) then
+        Refresh_AltCityOverlapLens();
+      end
+    end
+
+    if SHOW_CITIZEN_MANAGEMENT_ONHOVER and m_EnableCitizenManagementArea then
+
+      -- Cancel if unit is selected or Modal Lens Panel is out
+      if (selectedUnit == nil and UI.GetInterfaceMode() ~= InterfaceModeTypes.VIEW_MODAL_LENS) then
+        if pPlot:IsCity() and pPlot:GetOwner() == Game.GetLocalPlayer() then
+          RefreshCitizenManagementArea();
+        elseif m_CitizenManagementOn then
+          ClearAreaLens()
+          m_CitizenManagementOn = false
+        end
+      end
+    end
+
+    -- Handler for alternate settler lens
+    if m_CtrlDown then
+      if selectedUnit ~= nil then
+        local unitType = GetUnitType(selectedUnit:GetOwner(), selectedUnit:GetID());
+        if unitType == "UNIT_SETTLER" then
+          RefreshSettlerLens();
+        else
+          print(unitType)
+        end
+
+      -- Clear Settler lens, if not in modal screen
+      elseif UI.GetInterfaceMode() ~= InterfaceModeTypes.VIEW_MODAL_LENS then
+
+        ClearSettlerLens();
+      end
+    end
+  end
+end
+
+-- ===========================================================================
+--  Utility/Helper Functions
+-- ===========================================================================
+
+function plotWithinWorkingRange(playerID, plotIndex)
+  local localPlayerCities = Players[playerID]:GetCities()
+  local pPlot = Map.GetPlotByIndex(plotIndex)
+  local plotX = pPlot:GetX()
+  local plotY = pPlot:GetY()
+
+  for _, pCity in localPlayerCities:Members() do
+    if Map.GetPlotDistance(plotX, plotY, pCity:GetX(), pCity:GetY()) <= CITY_WORK_RANGE then
+      return true
+    end
+  end
+  return false
 end
 
 function plotHasImprovement(plot)
@@ -1466,9 +2291,13 @@ function plotHasRemovableFeature(plot)
   return false;
 end
 
-function plotHasHill(plot)
+function plotHasImprovableHill(plot)
   local terrainInfo = GameInfo.Terrains[plot:GetTerrainType()];
-  if terrainInfo ~= nil and terrainInfo.Hills then
+  local improvInfo = GameInfo.Improvements["IMPROVEMENT_MINE"];
+  local playerID = Game.GetLocalPlayer()
+
+  if (terrainInfo ~= nil and terrainInfo.Hills
+      and playerCanHave(playerID, improvInfo)) then
     return true
   end
   return false;
@@ -1542,16 +2371,22 @@ function plotNextToBuffingWonder(plot)
 end
 
 function plotHasRecomFeature(plot)
+  local playerID = Game.GetLocalPlayer()
   local featureInfo = GameInfo.Features[plot:GetFeatureType()]
+  local farmImprovInfo = GameInfo.Improvements["IMPROVEMENT_FARM"]
+  local lumberImprovInfo = GameInfo.Improvements["IMPROVEMENT_LUMBER_MILL"]
+
   if featureInfo ~= nil then
 
     -- 1. Is it a floodplain?
-    if featureInfo.FeatureType == "FEATURE_FLOODPLAINS" then
+    if featureInfo.FeatureType == "FEATURE_FLOODPLAINS" and
+        playerCanHave(playerID, farmImprovInfo) then
       return true
     end
 
     -- 2. Is it a forest next to a river?
-    if featureInfo.FeatureType == "FEATURE_FOREST" and plot:IsRiver() then
+    if featureInfo.FeatureType == "FEATURE_FOREST" and plot:IsRiver() and
+        playerCanHave(playerID, lumberImprovInfo) then
       return true
     end
 
@@ -1562,9 +2397,15 @@ function plotHasRecomFeature(plot)
 
     -- 4. Is it wonder, that can have an improvement?
     if plotHasImprovableWonder(plot) then
-      return true
-    end
+      if featureInfo.FeatureType == "FEATURE_FOREST" and
+          playerCanHave(playerID, lumberImprovInfo) then
+        return true
+      end
 
+      if plotCanHaveFarm(plot) then
+        return true
+      end
+    end
   end
 
   return false
@@ -1593,6 +2434,25 @@ function plotHasBarbCamp(plot)
     return true;
   end
   return false;
+end
+
+-- TODO: Check for valid feature
+function plotCanHaveFarm(plot)
+  local farmImprovInfo = GameInfo.Improvements["IMPROVEMENT_FARM"]
+  if not playerCanHave(playerID, farmImprovInfo) then
+    return false;
+  end
+
+  local validTerrain:boolean = false;
+  local playerID = Game.GetLocalPlayer()
+
+  for improvTerrainInfo in GameInfo.Improvement_ValidTerrains() do
+    if (improvTerrainInfo.ImprovementType == "IMPROVEMENT_FARM"
+        and playerCanHave(playerID, improvTerrainInfo)) then
+      return true;
+    end
+  end
+  return false
 end
 
 function plotHasGoodyHut(plot)
@@ -2001,6 +2861,51 @@ function GetUnitType( playerID: number, unitID : number )
   return nil;
 end
 
+function has_value (tab, val)
+  for _, value in ipairs (tab) do
+    if value == val then
+      return true
+    end
+  end
+  return false
+end
+
+function has_rInfo (tab, val)
+  for _, value in ipairs (tab) do
+    if value.ResourceType == val then
+      return true
+    end
+  end
+  return false
+end
+
+function find_and_remove(tab, val)
+  for i, item in ipairs(tab) do
+    if item == val then
+      table.remove(tab, i);
+      return
+    end
+  end
+end
+
+function ndup_insert(tab, val)
+  if not has_value(tab, val) then
+    table.insert(tab, val);
+  end
+end
+
+function get_common_values(tab1, tab2)
+  local common_table = {}
+  for _, value1 in ipairs (tab1) do
+    for _, value2 in ipairs (tab2) do
+      if value1 == value2 then
+        table.insert(common_table, value1)
+      end
+    end
+  end
+  return common_table
+end
+
 --------------------------------------------
 -- Plot Iterator, Author: whoward69; URL: https://forums.civfanatics.com/threads/border-and-area-plot-iterators.474634/
   -- convert funcs odd-r offset to axial. URL: http://www.redblobgames.com/grids/hexagons/
@@ -2197,9 +3102,13 @@ function OnInputActionTriggered( actionId )
     UI.PlaySound("Play_UI_Click");
   end
   if m_ToggleTourismLensId ~= nil and (actionId == m_ToggleTourismLensId) then
-        LensPanelHotkeyControl( Controls.TourismLensButton );
-        ToggleTourismLens();
-        UI.PlaySound("Play_UI_Click");
+    LensPanelHotkeyControl( Controls.TourismLensButton );
+    ToggleTourismLens();
+    UI.PlaySound("Play_UI_Click");
+  end
+  if m_Toggle2DViewId ~= nil and (actionId == m_Toggle2DViewId) then
+    UI.PlaySound("Play_UI_Click");
+    Toggle2DView();
   end
 end
 
@@ -2207,6 +3116,23 @@ end
 --  Game Engine Event
 -- ===========================================================================
 function OnInterfaceModeChanged(eOldMode:number, eNewMode:number)
+
+  if SHOW_CITIZEN_MANAGEMENT_INSCREEN then
+    if eOldMode == InterfaceModeTypes.CITY_MANAGEMENT then
+      ClearAreaLens()
+      m_EnableCitizenManagementArea = true;
+      m_CitizenManagementOn = false
+    end
+
+    if eNewMode == InterfaceModeTypes.CITY_MANAGEMENT then
+      local selectedCity = UI.GetHeadSelectedCity();
+      if (selectedCity ~= nil) then
+        RefreshCitizenManagementArea(selectedCity:GetID())
+        m_EnableCitizenManagementArea = false;
+      end
+    end
+  end
+
   --and eNewMode ~= InterfaceModeTypes.VIEW_MODAL_LENS
   if eOldMode == InterfaceModeTypes.VIEW_MODAL_LENS then
     if not Controls.LensPanel:IsHidden() then
@@ -2230,13 +3156,21 @@ function OnInterfaceModeChanged(eOldMode:number, eNewMode:number)
       Controls.WonderLensButton:SetCheck(false);
       Controls.ResourceLensButton:SetCheck(false);
       Controls.BarbarianLensButton:SetCheck(false);
-      Controls.CityOverlap9LensButton:SetCheck(false);
-      Controls.CityOverlap6LensButton:SetCheck(false);
+      Controls.CityOverlapLensButton:SetCheck(false);
       Controls.ArchaeologistLensButton:SetCheck(false);
       Controls.BuilderLensButton:SetCheck(false);
+      Controls.NaturalistLensButton:SetCheck(false);
 
-      if GetCurrentModdedLens() ~= MODDED_LENS_ID.NONE then
+      -- Side Menus
+      Controls.ResourceLensOptionsPanel:SetHide(true);
+      Controls.OverlapLensOptionsPanel:SetHide(true);
+
+      if m_CurrentModdedLensOn ~= MODDED_LENS_ID.NONE then
         ClearModdedLens()
+      end
+
+      if m_CurrentAreaLensOn ~= AREA_LENS_ID.NONE then
+        ClearAreaLens()
       end
     end
   end
@@ -2263,6 +3197,8 @@ function OnUnitSelectionChanged( playerID:number, unitID:number, hexI:number, he
           ClearArchaeologistLens();
         elseif (unitType == "UNIT_SCOUT" or unitType == "UNIT_RANGER") and AUTO_APPLY_SCOUT_LENS then
           ClearScoutLens();
+        elseif (unitType == "UNIT_SETTLER") then
+          ClearSettlerLens();
         end
       end
     end
@@ -2304,12 +3240,11 @@ function OnUnitRemovedFromMap( playerID: number, unitID : number )
   local localPlayer = Game.GetLocalPlayer()
 
   if playerID == localPlayer then
-    currentModdedLens = GetCurrentModdedLens();
-    if currentModdedLens == MODDED_LENS_ID.BUILDER then
+    if m_CurrentModdedLensOn == MODDED_LENS_ID.BUILDER then
       ClearBuilderLensHexes();
-    elseif currentModdedLens == MODDED_LENS_ID.ARCHAEOLOGIST then
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.ARCHAEOLOGIST then
       ClearArchaeologistLens();
-    elseif currentModdedLens == MODDED_LENS_ID.SCOUT then
+    elseif m_CurrentModdedLensOn == MODDED_LENS_ID.SCOUT then
       ClearScoutLens();
     end
   end
@@ -2319,11 +3254,10 @@ end
 function OnUnitMoved( playerID:number, unitID:number )
   if playerID == Game.GetLocalPlayer() then
     local unitType = GetUnitType(playerID, unitID);
-    local currentModdedLens = GetCurrentModdedLens();
     if (unitType == "UNIT_SCOUT" or unitType == "UNIT_RANGER") and AUTO_APPLY_SCOUT_LENS then
       -- Refresh the scout lens, if already applied. Need this check so scout lens
       -- does not apply when a scout is currently under a operation
-      if currentModdedLens == MODDED_LENS_ID.SCOUT then
+      if m_CurrentModdedLensOn == MODDED_LENS_ID.SCOUT then
         ClearScoutLens();
         ShowScoutLens();
       end
@@ -2331,26 +3265,19 @@ function OnUnitMoved( playerID:number, unitID:number )
   end
 end
 
-function HandleMouseForModdedLens( mousex:number, mousey:number )
-  -- Don't do anything if mouse is dragging
-  if not m_isMouseDragging then
-    local plotId = UI.GetCursorPlotID();
-    if (not Map.IsPlot(plotId)) then
-      return;
+function OnCityWorkerChanged(ownerPlayerID:number, cityID:number)
+  if SHOW_CITIZEN_MANAGEMENT_INSCREEN and ownerPlayerID == Game.GetLocalPlayer() then
+    RefreshCitizenManagementArea(cityID)
+  end
     end
 
-    local pPlot = Map.GetPlotByIndex(plotId)
+function OnCityMadePurchase(owner:number, cityID:number, plotX:number, plotY:number, purchaseType, objectType)
+  if SHOW_CITIZEN_MANAGEMENT_INSCREEN and owner == Game.GetLocalPlayer()
+      and purchaseType == EventSubTypes.PLOT then
 
-    -- Handle for different lenses
-    if UILens.IsLayerOn(LensLayers.HEX_COLORING_WATER_AVAILABLITY) then
-      -- Alt_ClearHighlightedPlots();
-      -- local highlightPlot:table = {}
-      -- for pAdjacencyPlot in PlotAreaSpiralIterator(pPlot, 3, SECTOR_NONE, DIRECTION_CLOCKWISE, DIRECTION_OUTWARDS, CENTRE_INCLUDE) do
-      --  table.insert(highlightPlot, pAdjacencyPlot:GetIndex())
-      -- end
-
-      -- Alt_HighlightPlots(highlightPlot);
-    end
+    -- Add plot so that the plot is properly cleared
+    table.insert(m_tAreaPlotsColored, Map.GetPlotIndex(plotX, plotY))
+    RefreshCitizenManagementArea(cityID)
   end
 end
 
@@ -2385,9 +3312,24 @@ function TranslateMinimapToWorld( minix:number, miniy:number )
 end
 
 function OnInputHandler( pInputStruct:table )
-  -- Skip all handling when dragging is disabled or the minimap is collapsed
+  local msg = pInputStruct:GetMessageType();
+  if pInputStruct:GetKey() == Keys.VK_CONTROL then
+    if msg == KeyEvents.KeyDown then
+      m_CtrlDown = true
+
+      -- Reset cursor plot to recalculate HandleMouseForModdedLens
+      m_CurrentCursorPlotID = -1;
+    elseif msg == KeyEvents.KeyUp then
+      m_CtrlDown = false
+
+      RecheckSettlerLens()
+    end
+  end
+
+  HandleMouseForModdedLens(pInputStruct:GetX(), pInputStruct:GetY())
+
+  -- Skip all other handling when dragging is disabled or the minimap is collapsed
   if m_isMouseDragEnabled and not m_isCollapsed then
-    local msg = pInputStruct:GetMessageType( );
 
     -- Enable drag on LMB down
     if msg == MouseEvents.LButtonDown then
@@ -2427,8 +3369,8 @@ function OnInputHandler( pInputStruct:table )
       m_wasMouseInMinimap = isMouseInMinimap
       return isMouseInMinimap; -- Only consume event if it's inside the minimap.
 
-    end
-    if msg == MouseEvents.RButtonDown or msg == MouseEvents.RButtonUp then
+    -- Consume mouse right click if mouse is on minimap.
+    elseif msg == MouseEvents.RButtonDown or msg == MouseEvents.RButtonUp then
       local minix, miniy = GetMinimapMouseCoords( pInputStruct:GetX(), pInputStruct:GetY() );
       if IsMouseInMinimap( minix, miniy ) then
         return true
@@ -2437,7 +3379,6 @@ function OnInputHandler( pInputStruct:table )
   end
   return false;
 end
-
 
 function OnTutorial_DisableMapDrag( isDisabled:boolean )
   m_isMouseDragEnabled = not isDisabled;
@@ -2461,9 +3402,12 @@ end
 -- ===========================================================================
 -- INITIALIZATION
 -- ===========================================================================
+
 function Initialize()
   m_MiniMap_xmloffsety = Controls.MiniMap:GetOffsetY();
   m_ContinentsCache = Map.GetContinentsInUse();
+
+  Controls.MinimapImage:RegisterSizeChanged( OnMinimapImageSizeChanged );
   UI.SetMinimapImageControl(Controls.MinimapImage);
   Controls.LensChooserList:CalculateSize();
 
@@ -2476,15 +3420,26 @@ function Initialize()
   Controls.ToggleYieldsButton:SetCheck( UserConfiguration.ShowMapYield() );
 
   -- Modded lens
-  Controls.ScoutLensButton:RegisterCallback( Mouse.eLClick, ToggleScoutLens );
-  Controls.AdjacencyYieldLensButton:RegisterCallback( Mouse.eLClick, ToggleAdjacencyYieldLens );
-  Controls.WonderLensButton:RegisterCallback( Mouse.eLClick, ToggleWonderLens );
-  Controls.ResourceLensButton:RegisterCallback( Mouse.eLClick, ToggleResourceLens );
-  Controls.BarbarianLensButton:RegisterCallback( Mouse.eLClick, ToggleBarbarianLens );
-  Controls.CityOverlap9LensButton:RegisterCallback( Mouse.eLClick, ToggleCityOverlap9Lens );
-  Controls.CityOverlap6LensButton:RegisterCallback( Mouse.eLClick, ToggleCityOverlap6Lens );
-  Controls.ArchaeologistLensButton:RegisterCallback( Mouse.eLClick, ToggleArchaeologistLens );
   Controls.BuilderLensButton:RegisterCallback( Mouse.eLClick, ToggleBuilderLens );
+  Controls.ArchaeologistLensButton:RegisterCallback( Mouse.eLClick, ToggleArchaeologistLens );
+  Controls.CityOverlapLensButton:RegisterCallback( Mouse.eLClick, ToggleCityOverlapLens );
+  Controls.BarbarianLensButton:RegisterCallback( Mouse.eLClick, ToggleBarbarianLens );
+  Controls.ResourceLensButton:RegisterCallback( Mouse.eLClick, ToggleResourceLens );
+  Controls.WonderLensButton:RegisterCallback( Mouse.eLClick, ToggleWonderLens );
+  Controls.AdjacencyYieldLensButton:RegisterCallback( Mouse.eLClick, ToggleAdjacencyYieldLens );
+  Controls.ScoutLensButton:RegisterCallback( Mouse.eLClick, ToggleScoutLens );
+  Controls.NaturalistLensButton:RegisterCallback( Mouse.eLClick, ToggleNaturalistLens );
+
+  -- Resource Lens Picker
+  Controls.ShowBonusResource:RegisterCallback( Mouse.eLClick, ToggleResourceLens_Bonus );
+  Controls.ShowLuxuryResource:RegisterCallback( Mouse.eLClick, ToggleResourceLens_Luxury );
+  Controls.ShowStrategicResource:RegisterCallback( Mouse.eLClick, ToggleResourceLens_Strategic );
+
+  -- City Overlap Lens Setting
+  Controls.ShowLensOutsideBorder:RegisterCallback( Mouse.eLClick, RefreshCityOverlapLens );
+  Controls.OverlapRangeUp:RegisterCallback( Mouse.eLClick, IncreseOverlapRange );
+  Controls.OverlapRangeDown:RegisterCallback( Mouse.eLClick, DecreaseOverlapRange );
+  Controls.OverlapLensMouseNone:RegisterCallback( Mouse.eLClick, RefreshCityOverlapLens );
 
   Controls.AppealLensButton:RegisterCallback( Mouse.eLClick, ToggleAppealLens );
   Controls.ContinentLensButton:RegisterCallback( Mouse.eLClick, ToggleContinentLens );
@@ -2553,5 +3508,19 @@ function Initialize()
   LuaEvents.CQUI_SettingsInitialized.Add( CQUI_UpdateMinimapSize );
   LuaEvents.CQUI_SettingsInitialized.Add( CQUI_ToggleYieldIcons );
   CQUI_OnSettingsUpdate(); --ARISTOS: to force lenses settings when first starting the game
+
+  -- For Area Lens
+  Events.CityWorkerChanged.Add( OnCityWorkerChanged );
+  Events.CityMadePurchase.Add( OnCityMadePurchase );
+
+  -- External Lens Controls
+  LuaEvents.Lens_ApplyCustomLens.Add( ApplyCustomLens );
+  LuaEvents.Lens_ClearCustomLens.Add( ClearCustomLens );
+  LuaEvents.Lens_ApplyModdedLens.Add( OnApplyModdedLens );
+  LuaEvents.Lens_ClearModdedLens.Add( OnClearModdedLens );
+  LuaEvents.Area_ShowCitizenManagement.Add( ShowCitizenManagementArea );
+  LuaEvents.Area_RefreshCitizenManagement.Add( RefreshCitizenManagementArea );
+  LuaEvents.Area_ClearCitizenManagement.Add( ClearAreaLens );
 end
+
 Initialize();

--- a/Integrations/ML/UI/minimappanel.lua
+++ b/Integrations/ML/UI/minimappanel.lua
@@ -47,11 +47,11 @@ local AUTO_APPLY_SCOUT_LENS:boolean = true;
 -- Show citizen management area when hovering over city plot
 local SHOW_CITIZEN_MANAGEMENT_ONHOVER:boolean = false;
 
--- Show citizen management when managing citizens
+-- Show citizen management area when managing citizens
 local SHOW_CITIZEN_MANAGEMENT_INSCREEN:boolean = true;
 
 -- Highlight nothing to do (red plots) in builder lens
-local HIGHLIGHT_NOTHING_TODO_IN_BUILDER_LENS:boolean = false;
+local SHOW_NOTHING_TODO_IN_BUILDER_LENS:boolean = false;
 
 local CITY_WORK_RANGE:number = 3;
 
@@ -167,6 +167,8 @@ function CQUI_OnSettingsUpdate()
   AUTO_APPLY_ARCHEOLOGIST_LENS = GameConfiguration.GetValue("CQUI_AutoapplyArchaeologistLens");
   AUTO_APPLY_BUILDER_LENS = GameConfiguration.GetValue("CQUI_AutoapplyBuilderLens");
   AUTO_APPLY_SCOUT_LENS = GameConfiguration.GetValue("CQUI_AutoapplyScoutLens");
+  SHOW_CITIZEN_MANAGEMENT_INSCREEN = GameConfiguration.GetValue("CQUI_ShowCityMangeAreaInScreen");
+  SHOW_NOTHING_TODO_IN_BUILDER_LENS = GameConfiguration.GetValue("CQUI_ShowNothingToDoBuilderLens");
 
   --Cycles the minimap after resizing
   CQUI_UpdateMinimapSize();
@@ -2006,6 +2008,7 @@ end
 
 -- ===========================================================================
 function ShowCitizenManagementArea(cityID)
+  print("Showing city manage area for " .. cityID)
   SetActiveAreaLens(AREA_LENS_ID.CITIZEN_MANAGEMENT)
   UILens.ToggleLayerOn(LensLayers.HEX_COLORING_GOVERNMENT)
 

--- a/Integrations/ML/UI/minimappanel.xml
+++ b/Integrations/ML/UI/minimappanel.xml
@@ -91,11 +91,11 @@
   <Container  Size="300,200"    ID="MiniMap" Anchor="L,B" Offset="-3,0" ConsumeMouse="0">
     <SlideAnim  Size="parent,parent"  ID="CollapseAnim" Begin="0,0" End="0,195" Function="OutQuint" FunctionPower="1" Speed="2"   Cycle="Once"  Stopped="1">
       <SlideAnim  Size="parent,parent" ID="ExpandAnim" Begin="0,0" End="0,-195" Function="OutQuint" FunctionPower="3" Speed="2"   Cycle="Once"  Stopped="1">
-        <Grid   ID="MinimapBacking" Texture="MiniMap_WoodBacking" Anchor ="L,B" Offset="-5,2" Size="282,201" SliceCorner="18,94" SliceSize="246,4">
+        <Grid   ID="MinimapBacking" Texture="MiniMap_WoodBacking" Anchor ="L,B" Offset="-5,2" Size="280, 201" SliceCorner="18,94" SliceSize="246,4">
           <Image Texture="MiniMap_WoodBackingTile" Anchor="C,C" Size="Parent-25,Parent-100" StretchMode="Tile"/>
         </Grid>
         <Image   ID="MinimapContainer" Anchor ="L,B" Texture="Parchment_Pattern" ToolTip="LOC_HUD_MINIMAP_TOOLTIP" Size="256,256" StretchMode="Tile" Offset="18,21">
-          <Image ID="MinimapImage"     Anchor ="C,C" Texture="MiniMap_BG.dds"    ToolTip="LOC_HUD_MINIMAP_TOOLTIP" Size="256,256" StretchMode="Fill" Sampler="Linear"/>
+          <Image ID="MinimapImage"     Anchor ="L,B" Offset="0,0" Texture="MiniMap_BG.dds"    ToolTip="LOC_HUD_MINIMAP_TOOLTIP" Size="parent,parent" StretchMode="Fill" Sampler="Linear"/>
 
           <Button ID="CollapseButton" Anchor="R,T" AnchorSide="I,O" Offset="3,3"  Size="47,16"  Hidden="0" Texture="Controls_Collapse.dds" ToolTip="LOC_HUD_MINIMAP_COLLAPSE_TOOLTIP" />
           <Button ID="ExpandButton" Anchor="R,T" AnchorSide="I,O" Offset="3,3"  Size="47,16"  Hidden="1" ConsumeAllMouse="1" Texture="Controls_ButtonExtend.dds" ToolTip="LOC_HUD_MINIMAP_EXPAND_TOOLTIP" />
@@ -109,6 +109,7 @@
             <CheckBox ID="MapOptionsButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40"  ButtonTexture="LaunchBar_Hook_ButtonSmall" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_OPTIONS" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
               <Image Texture="Minimap_MapOptions" Size="22,22" Anchor="C,C"/>
             </CheckBox>
+            <Image                       Anchor="L,C" Size="7,7"    Texture="LaunchBar_TrackPip" Color="255,255,255,200" Offset="0,-2"/>
             <CheckBox ID="CQUI_OptionsButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40"  ButtonTexture="LaunchBar_Hook_ButtonSmall" Style="ButtonNormalText" ToolTip="LOC_CQUI_NAME" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
               <Image Texture="Stats30" Icon="ICON_RESOURCE_TOBACCO" Size="35,35" Anchor="C,C"/>
             </CheckBox>

--- a/Integrations/ML/UI/minimappanel.xml
+++ b/Integrations/ML/UI/minimappanel.xml
@@ -1,31 +1,79 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Context>
 
-  <SlideAnim  Size="parent,parent"  ID="Pause" Begin="0,0" End="0,160" Function="Root" Speed="4"    Cycle="Once"  Stopped="1"/>
+  <SlideAnim  Size="parent,parent"    ID="Pause" Begin="0,0" End="0,160" Function="Root" Speed="4"        Cycle="Once"    Stopped="1"/>
 
-    <Grid             ID="LensPanel"            Anchor="L,T" AnchorSide="I,O"                 Offset="-10,-5" Size="230,386"  Texture="Tracker_OptionsBacking.dds" SliceCorner="55,61" SliceSize="1,1" SliceTextureSize="121,119" ConsumeAllMouse="1" Hidden="1">
-    <Label                                    Anchor="C,T" String="{LOC_HUD_LENSES:upper}"  Offset="-6,10"  Style="FontFlair16" Color0="106,93,69,255" Color1="0,0,0,150" Color2="146,133,109,255" FontStyle="Glow" SmallCaps="20" SmallCapsLeading="0" SmallCapsType="EveryWord" KerningAdjustment="0"/>
-    <ScrollPanel    ID="LensChooserList"                                          Offset="36,35"  Size="parent,parent-65" Style="ScrollPanelWithLeftBar">
-      <Stack      ID="LensToggleStack"      Anchor="L,T"              StackGrowth="Down"  Offset="-5,0" StackPadding="0" >
-        <RadioButton  ID="ReligionLensButton"   RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_RELIGION_LENS"    AllowClickOff="1" ToolTip="LOC_HUD_RELIGION_LENS_TOOLTIP"   Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
-        <RadioButton  ID="ContinentLensButton"  RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_CONTINENT_LENS"   AllowClickOff="1" ToolTip="LOC_HUD_CONTINENT_LENS_TOOLTIP"  Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
-        <RadioButton  ID="AppealLensButton"     RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_APPEAL_LENS"      AllowClickOff="1" ToolTip="LOC_HUD_APPEAL_LENS_TOOLTIP"     Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
-        <RadioButton  ID="WaterLensButton"      RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_WATER_LENS"       AllowClickOff="1" ToolTip="LOC_HUD_WATER_LENS_TOOLTIP"      Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
-        <RadioButton  ID="GovernmentLensButton" RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_GOVERNMENT_LENS"  AllowClickOff="1" ToolTip="LOC_HUD_GOVERNMENT_LENS_TOOLTIP" Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
-        <RadioButton  ID="OwnerLensButton"      RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_OWNER_LENS"       AllowClickOff="1" ToolTip="LOC_HUD_OWNER_LENS_TOOLTIP"      Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
-        <RadioButton  ID="TourismLensButton"    RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_TOURISM_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_TOURISM_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
-        <RadioButton  ID="BuilderLensButton"    RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_BUILDER_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_BUILDER_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
-        <RadioButton  ID="ArchaeologistLensButton"  RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_ARCHAEOLOGIST_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_ARCHAEOLOGIST_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
-        <RadioButton  ID="CityOverlap6LensButton"   RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_CITYOVERLAP6_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_CITYOVERLAP6_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
-        <RadioButton  ID="CityOverlap9LensButton"   RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_CITYOVERLAP9_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_CITYOVERLAP9_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
-        <RadioButton  ID="BarbarianLensButton"    RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_BARBARIAN_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_BARBARIAN_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
-        <RadioButton  ID="ResourceLensButton"   RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_RESOURCE_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_RESOURCE_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
-        <RadioButton  ID="WonderLensButton"   RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_WONDER_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_WONDER_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
-        <RadioButton  ID="AdjacencyYieldLensButton"   RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_ADJYIELD_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_ADJYIELD_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
-        <RadioButton  ID="ScoutLensButton"    RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_SCOUT_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_SCOUT_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
+  <Grid                           ID="LensPanel"                      Anchor="L,T" AnchorSide="I,O"                               Offset="-10,-5" Size="230,386"  Texture="Tracker_OptionsBacking.dds" SliceCorner="55,61" SliceSize="1,1" SliceTextureSize="121,119" ConsumeAllMouse="1" Hidden="1">
+    <Label                                                                      Anchor="C,T" String="{LOC_HUD_LENSES:upper}"    Offset="-6,10"  Style="FontFlair16" Color0="106,93,69,255" Color1="0,0,0,150" Color2="146,133,109,255" FontStyle="Glow" SmallCaps="20" SmallCapsLeading="0" SmallCapsType="EveryWord" KerningAdjustment="0"/>
+    <ScrollPanel        ID="LensChooserList"                                                                                    Offset="36,35"  Size="parent,parent-65" Style="ScrollPanelWithLeftBar">
+      <Stack          ID="LensToggleStack"            Anchor="L,T"                            StackGrowth="Down"  Offset="-5,0" StackPadding="0" >
+        <RadioButton    ID="ReligionLensButton"   RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_RELIGION_LENS"    AllowClickOff="1" ToolTip="LOC_HUD_RELIGION_LENS_TOOLTIP"   Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds"   ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
+        <RadioButton    ID="ContinentLensButton"  RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_CONTINENT_LENS"   AllowClickOff="1" ToolTip="LOC_HUD_CONTINENT_LENS_TOOLTIP"  Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds"   ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
+        <RadioButton    ID="AppealLensButton"     RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_APPEAL_LENS"      AllowClickOff="1" ToolTip="LOC_HUD_APPEAL_LENS_TOOLTIP"     Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds"   ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
+        <RadioButton    ID="WaterLensButton"      RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_WATER_LENS"       AllowClickOff="1" ToolTip="LOC_HUD_WATER_LENS_TOOLTIP"      Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds"   ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
+        <RadioButton    ID="GovernmentLensButton" RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_GOVERNMENT_LENS"  AllowClickOff="1" ToolTip="LOC_HUD_GOVERNMENT_LENS_TOOLTIP" Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds"   ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
+        <RadioButton    ID="OwnerLensButton"      RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_OWNER_LENS"       AllowClickOff="1" ToolTip="LOC_HUD_OWNER_LENS_TOOLTIP"      Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds"   ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
+        <RadioButton    ID="TourismLensButton"    RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_TOURISM_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_TOURISM_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds"   ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
+        <RadioButton    ID="BuilderLensButton"    RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_BUILDER_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_BUILDER_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds"   ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
+        <RadioButton    ID="ArchaeologistLensButton"    RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_ARCHAEOLOGIST_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_ARCHAEOLOGIST_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4"   ButtonTexture="Controls_RadioButtonLarge.dds"   ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
+        <RadioButton    ID="CityOverlapLensButton"     RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_CITYOVERLAP_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_CITYOVERLAP_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds"   ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
+        <RadioButton    ID="BarbarianLensButton"        RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_BARBARIAN_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_BARBARIAN_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4"   ButtonTexture="Controls_RadioButtonLarge.dds"   ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
+        <RadioButton    ID="ResourceLensButton"     RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_RESOURCE_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_RESOURCE_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds"   ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
+        <RadioButton    ID="WonderLensButton"       RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_WONDER_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_WONDER_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds"   ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
+        <RadioButton    ID="AdjacencyYieldLensButton"       RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_ADJYIELD_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_ADJYIELD_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4" ButtonTexture="Controls_RadioButtonLarge.dds"   ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
+        <RadioButton    ID="ScoutLensButton"        RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_SCOUT_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_SCOUT_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4"   ButtonTexture="Controls_RadioButtonLarge.dds"   ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
+        <RadioButton    ID="NaturalistLensButton"        RadioGroup="ActiveLens" TextOffset="-5,0" String="LOC_HUD_NATURALIST_LENS"     AllowClickOff="1" ToolTip="LOC_HUD_NATURALIST_LENS_TOOLTIP"    Style="WhiteSemiBold14" Offset="10,4"   ButtonTexture="Controls_RadioButtonLarge.dds"   ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35"  Anchor="L,T" BoxOnLeft="1"/>
       </Stack>
     </ScrollPanel>
     <Image Texture="Controls_ButtonExtendSmall" TextureOffset="0,60" Size="20,20" Anchor="L,B" Offset="22,10"/>
+
+    <!-- Resource Lens Options -->
+    <Grid ID="ResourceLensOptionsPanel" Anchor="R,B" Offset="-210,0" Size="230,350"  Texture="Tracker_OptionsBacking.dds" SliceCorner="55,61" SliceSize="1,1" SliceTextureSize="121,119" ConsumeAllMouse="1" Hidden="1">
+      <Label Anchor="C,T" String="{LOC_HUD_RESOURCE_LENS:upper}" Offset="-6,10"  Style="FontFlair16" Color0="106,93,69,255" Color1="0,0,0,150" Color2="146,133,109,255" FontStyle="Glow" SmallCaps="20" SmallCapsLeading="0" SmallCapsType="EveryWord" KerningAdjustment="0" AutoScrollBar="1" AutoSizeScrollBar="1"/>
+      <ScrollPanel ID="ResourcePickList" Anchor="L,T" Offset="35,35" Size="parent,parent-65" Style="ScrollPanelWithLeftBar">
+        <Stack ID="ResourcePickStack" Anchor="L,T" StackGrowth="Down" Offset="-10,0" StackPadding="5">
+
+          <!-- BONUS -->
+          <CheckBox   ID="ShowBonusResource"               IsChecked="1"   Offset="15,4"   BoxOnLeft="1" TextOffset="-5,0" String="LOC_TOOLTIP_RESOURCE_LENS_BONUS" Style="WhiteSemiBold14" ButtonTexture="Controls_Checkbox.dds"    ButtonSize="17,17" CheckTexture="Controls_Checkbox.dds" CheckSize="17,17" CheckTextureOffset="0,17"  Anchor="L,T"/>
+            <Stack ID="BonusResourcePickStack" Anchor="L,T" StackGrowth="Down" Offset="40,-3" StackPadding="0">
+            </Stack>
+
+          <!-- LUXURY -->
+          <CheckBox   ID="ShowLuxuryResource"               IsChecked="1"   Offset="15,4"   BoxOnLeft="1" TextOffset="-5,0" String="LOC_TOOLTIP_RESOURCE_LENS_LUXURY" Style="WhiteSemiBold14" ButtonTexture="Controls_Checkbox.dds"    ButtonSize="17,17" CheckTexture="Controls_Checkbox.dds" CheckSize="17,17" CheckTextureOffset="0,17"  Anchor="L,T"/>
+            <Stack ID="LuxuryResourcePickStack" Anchor="L,T" StackGrowth="Down" Offset="40,-3" StackPadding="0">
+            </Stack>
+
+          <!-- STRATEGIC -->
+          <CheckBox   ID="ShowStrategicResource"               IsChecked="1"   Offset="15,4"   BoxOnLeft="1" TextOffset="-5,0" String="LOC_TOOLTIP_RESOURCE_LENS_STRATEGIC" Style="WhiteSemiBold14" ButtonTexture="Controls_Checkbox.dds"    ButtonSize="17,17" CheckTexture="Controls_Checkbox.dds" CheckSize="17,17" CheckTextureOffset="0,17"  Anchor="L,T"/>
+            <Stack ID="StrategicResourcePickStack" Anchor="L,T" StackGrowth="Down" Offset="40,-3" StackPadding="0">
+            </Stack>
+
+        </Stack>
+      </ScrollPanel>
+    </Grid>
+
+    <!-- City Overlap Lens Options -->
+    <Grid ID="OverlapLensOptionsPanel" Anchor="R,B" Offset="-210,0" Size="230,350"  Texture="Tracker_OptionsBacking.dds" SliceCorner="55,61" SliceSize="1,1" SliceTextureSize="121,119" ConsumeAllMouse="1" Hidden="1">
+      <Label Anchor="C,T" String="{LOC_HUD_CITYOVERLAP_LENS:upper}" Offset="-6,10"  Style="FontFlair16" Color0="106,93,69,255" Color1="0,0,0,150" Color2="146,133,109,255" FontStyle="Glow" SmallCaps="20" SmallCapsLeading="0" SmallCapsType="EveryWord" KerningAdjustment="0" AutoScrollBar="1" AutoSizeScrollBar="1"/>
+
+      <Stack StackGrowth="Down" Padding="10">
+        <CheckBox ID="ShowLensOutsideBorder" WrapWidth="120" IsChecked="1" Offset="25,50" BoxOnLeft="1" TextOffset="-9,0" String="LOC_PANEL_CITYOVERLAP_OPTION1" Style="WhiteSemiBold14" ButtonTexture="Controls_Checkbox.dds" ButtonSize="17,17" CheckTexture="Controls_Checkbox.dds" CheckSize="17,17" CheckTextureOffset="0,17" Anchor="L,T"/>
+
+        <RadioButton ID="OverlapLensMouseNone" IsChecked="1" RadioGroup="OverlapMouse" TextOffset="-1,-1" String="LOC_PANEL_CITYOVERLAP_NMOUSE" Style="WhiteSemiBold14" Offset="17,4" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35" Anchor="L,T" BoxOnLeft="1"/>
+
+        <RadioButton ID="OverlapLensMouseRange" RadioGroup="OverlapMouse" TextOffset="-1,-1" String="LOC_PANEL_CITYOVERLAP_RANGE" ToolTip="LOC_TOOLTIP_CITYOVERLAP_RANGE" Style="WhiteSemiBold14" Offset="17,0" ButtonTexture="Controls_RadioButtonLarge.dds" ButtonSize="35,35" CheckTexture="Controls_RadioButtonLarge.dds" CheckSize="35,35" CheckTextureOffset="0,35" Anchor="L,T" BoxOnLeft="1"/>
+      </Stack>
+
+      <Container Anchor="C,B" Offset="-5,50" Size="parent-45,70">
+        <Grid Texture="Controls_SeparatorAngled" TextureSize="14,6" Anchor="C,T" Size="parent,6" SliceCorner="6,4" Offset="0,0"/>
+
+        <Label Anchor="C,T" Offset="0,15" String="RANGE" WrapWidth="Parent-40" Align="Center" Style="FontFlair16" Color2="143,122,82,255" Color0="106,93,69,230" SmallCaps="20" SmallCapsLeading="0" SmallCapsType="EveryWord" KerningAdjustment="0" />
+
+        <Button ID="OverlapRangeDown" Style="ArrowButtonLeft" Offset="20,24" Anchor="L,C"/>
+        <Button ID="OverlapRangeUp" Style="ArrowButtonRight" Offset="20,24" Anchor="R,C"/>
+        <Label ID="OverlapRangeLabel"  String="6" Offset="0,24" Anchor="C,C" Align="Center" Style="EventPopupTitle" />
+      </Container>
+    </Grid>
   </Grid>
 
   <Grid           ID="MapOptionsPanel"  Anchor="L,T" AnchorSide="I,O"     Size="220,119"  Offset="-10,-5" Texture="Tracker_OptionsBacking.dds" SliceCorner="55,61" SliceSize="1,1" SliceTextureSize="121,119" ConsumeAllMouse="1" Hidden="1">
@@ -39,14 +87,21 @@
     </ScrollPanel>
     <Image Texture="Controls_ButtonExtendSmall" TextureOffset="0,60" Size="20,20" Anchor="L,B" Offset="20,10"/>
   </Grid>
-  <Container  Size="300,200"    ID="MiniMap" Anchor="L,B" Offset="-15,-15" ConsumeMouse="0">
+
+  <Container  Size="300,200"    ID="MiniMap" Anchor="L,B" Offset="-3,0" ConsumeMouse="0">
     <SlideAnim  Size="parent,parent"  ID="CollapseAnim" Begin="0,0" End="0,195" Function="OutQuint" FunctionPower="1" Speed="2"   Cycle="Once"  Stopped="1">
       <SlideAnim  Size="parent,parent" ID="ExpandAnim" Begin="0,0" End="0,-195" Function="OutQuint" FunctionPower="3" Speed="2"   Cycle="Once"  Stopped="1">
-        <Image ID="MinimapImage" Anchor ="L,B" Offset="18,21" Texture="MiniMap_BG.dds" ToolTip="LOC_HUD_MINIMAP_TOOLTIP" StretchMode="Fill" Sampler="Linear" Size="512,256">
+        <Grid   ID="MinimapBacking" Texture="MiniMap_WoodBacking" Anchor ="L,B" Offset="-5,2" Size="282,201" SliceCorner="18,94" SliceSize="246,4">
+          <Image Texture="MiniMap_WoodBackingTile" Anchor="C,C" Size="Parent-25,Parent-100" StretchMode="Tile"/>
+        </Grid>
+        <Image   ID="MinimapContainer" Anchor ="L,B" Texture="Parchment_Pattern" ToolTip="LOC_HUD_MINIMAP_TOOLTIP" Size="256,256" StretchMode="Tile" Offset="18,21">
+          <Image ID="MinimapImage"     Anchor ="C,C" Texture="MiniMap_BG.dds"    ToolTip="LOC_HUD_MINIMAP_TOOLTIP" Size="256,256" StretchMode="Fill" Sampler="Linear"/>
+
           <Button ID="CollapseButton" Anchor="R,T" AnchorSide="I,O" Offset="3,3"  Size="47,16"  Hidden="0" Texture="Controls_Collapse.dds" ToolTip="LOC_HUD_MINIMAP_COLLAPSE_TOOLTIP" />
           <Button ID="ExpandButton" Anchor="R,T" AnchorSide="I,O" Offset="3,3"  Size="47,16"  Hidden="1" ConsumeAllMouse="1" Texture="Controls_ButtonExtend.dds" ToolTip="LOC_HUD_MINIMAP_EXPAND_TOOLTIP" />
+
           <Grid Texture="MiniMap_Frame" Size="parent+10,parent+12" SliceCorner="18,40" SliceTextureSize="37,149" Offset="-5,-5"/>
-          <Stack ID="OptionsStack" Anchor="L,T" AnchorSide="I,O" Offset="0,-15" StackGrowth="Right" Padding="-3">
+          <Stack ID="OptionsStack" Anchor="L,T" AnchorSide="I,O" Offset="0,-4" StackGrowth="Right" Padding="-2">
             <CheckBox ID="LensButton" Offset="0,1" Anchor="L,C" UseSelectedTextures="1" ButtonSize="44,44"  ButtonTexture="LaunchBar_Hook_ButtonMedium" Style="ButtonNormalText" ToolTip="LOC_HUD_LENSES" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
               <Image Texture="MiniMap_Lenses" Size="36,36" Anchor="C,C" Offset="-4,-1"/>
             </CheckBox>
@@ -71,11 +126,19 @@
             <Image                       Anchor="L,C" Size="7,7"    Texture="LaunchBar_TrackPip" Color="255,255,255,200" Offset="0,-2"/>
           </Stack>
         </Image>
-        <Container Anchor="L,B" Offset="10,8">
+        <Container Anchor="L,B" Offset="7,8">
           <Meter ID="CompassArm" Offset="-169,-152" Texture="MiniMap_CompassSide.dds"  Percent=".25" Follow="1" Speed="4" Size="320,320"/>
           <Image Anchor="L,B" Offset="0,-6" Texture="MiniMap_CompassBase.dds"  />
         </Container>
       </SlideAnim>
     </SlideAnim>
   </Container>
+
+  <Instance Name="ResourcePickEntry">
+    <Container Size="130,20">
+      <CheckBox ID="ResourceCheckbox" IsChecked="1" Anchor="L,C" ButtonTexture="Controls_Checkbox.dds" ButtonSize="17,17" CheckTexture="Controls_Checkbox.dds" CheckSize="17,17" CheckTextureOffset="0,17" Anchor="L,T"/>
+      <Label ID="ResourceLabel" String="$Resource$" Anchor="L,C" Offset="17,1" Style="WhiteSemiBold14"/>
+    </Container>
+  </Instance>
+
 </Context>

--- a/Integrations/ML/morelenses_colors.sql
+++ b/Integrations/ML/morelenses_colors.sql
@@ -66,3 +66,30 @@ VALUES                  (   'COLOR_PLAYER_WONDER_LENS',         '0.98',     '0.0
 
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
 VALUES                  (   'COLOR_GHUT_SCOUT_LENS',            '0.56',     '0.0',      '0.98',     '0.5');
+
+-- Naturalist Lens
+INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_PARK_NATURALIST_LENS',       '0',        '1',        '0',        '0.5');
+INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_OK_NATURALIST_LENS',         '0',        '1',        '1',        '0.5');
+INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_FIXABLE_NATURALIST_LENS',    '0.56',     '0.0',      '0.98',     '0.5');
+
+
+-- City Manager Colors
+INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_CITY_PLOT_WORKING',          '1',        '0.5',      '0',        '0.2');
+INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_CITY_PLOT_LOCKED',           '0',        '1',        '0',        '0.2');
+INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_AREA_LENS_NEUTRAL',          '0',        '0',        '0',        '0.0');
+
+-- Alternate Settler Colors
+INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_ALT_SETTLER_RESOURCE',       '0.37',     '0',        '0.72',     '0.5');
+INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_ALT_SETTLER_UNUSABLE',       '1',        '0',        '0',        '0.5');
+INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_ALT_SETTLER_OVERLAP',        '0.75',     '0.75',     '0.75',     '0.5');
+INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
+VALUES                  (   'COLOR_ALT_SETTLER_REGULAR',        '0',        '0.75',     '0',        '0.5');


### PR DESCRIPTION
This updates ML to the latest version. Changes in ML:
- City Overlap lens side panel added
- Resource lens side panel added
- Combined city overlap lenses
- Overhauled naturalist lens. Big thanks to @pspjuth for his original code in #562 
- Added alternate mode for Settler Lens. Hold CTRL when a settler is selected to show plots around settler that are overlapped city plots, resource plots, or impassable/other player owned plots.
- Added overlay for citizen management area

Changes to CQUI stuff:
- Fixes with minimap resizing
- Added options for citizen management overlay. Resolves #598 
- Added option for builder lens to hide nothing to do hexes
- Small tweaks to default setting to not stretch the citizen icons

Things to note:
- Since there were changes to text, a localization pass will need to be done
- Testing for this was limited. I couldn't test a lot because of turn progressing bug. If you find something, let me know and I will push a commit to this branch.