### PR TITLE
More Lenses Fixes

### DIFF
--- a/Assets/Text/cqui_text_settings.xml
+++ b/Assets/Text/cqui_text_settings.xml
@@ -156,11 +156,17 @@
     <Row Tag="LOC_CQUI_LENSES_AUTOAPPLYSCOUTLENS" Language="en_US">
       <Text>Autoapply scout lens</Text>
     </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWNOTHINGTODO" Language="en_US">
+    <Row Tag="LOC_CQUI_LENSES_SHOWNOTHINGTODO_BUILDER" Language="en_US">
       <Text>Show nothing to do in builder lens</Text>
     </Row>
-    <Row Tag="LOC_CQUI_LENSES_SHOWNOTHINGTODO_TOOLTIP" Language="en_US">
+    <Row Tag="LOC_CQUI_LENSES_SHOWNOTHINGTODO_BUILDER_TOOLTIP" Language="en_US">
       <Text>Shows nothing to do hexes (red tiles) when in builder lens</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_LENSES_SHOWGENERIC_BUILDER" Language="en_US">
+      <Text>Show generic in builder lens</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_LENSES_SHOWGENERIC_BUILDER_TOOLTIP" Language="en_US">
+      <Text>Shows generic hexes (white tiles) when in builder lens</Text>
     </Row>
     <Row Tag="LOC_CQUI_POPUPS" Language="en_US">
       <Text>Popups</Text>

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -36,6 +36,7 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
       ("CQUI_AutoapplyBuilderLens", 1), -- Automatically activates the builder lens when selecting a builder
       ("CQUI_AutoapplyScoutLens", 1), -- Automatically activates the scout lens when selecting a scout
       ("CQUI_ShowNothingToDoBuilderLens", 1), -- Shows nothing to do hexes (red tiles) when in builder lens
+      ("CQUI_ShowGenericBuilderLens", 1), -- Shows generic hexes (white tiles) when in builder lens
       ("CQUI_AutoExpandUnitActions", 1), -- Automatically reveals the secondary unit actions normally hidden inside an expando
       ("CQUI_BlockOnCityAttack", 1), -- Block turn from ending if you have a city that can attack
       ("CQUI_ProductionQueue", 1), -- A production queue appears next to the production panel, allowing multiple constructions to be queued at once

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -297,10 +297,14 @@ function Initialize()
   PopulateCheckBox(Controls.TechVisualCheckbox, "CQUI_TechPopupVisual", Locale.Lookup("LOC_CQUI_POPUPS_TECHVISUAL_TOOLTIP"));
   PopulateCheckBox(Controls.TechAudioCheckbox, "CQUI_TechPopupAudio", Locale.Lookup("LOC_CQUI_POPUPS_TECHAUDIO_TOOLTIP"));
   PopulateCheckBox(Controls.TrimGossipCheckbox, "CQUI_TrimGossip", Locale.Lookup("LOC_CQUI_GOSSIP_TRIMMESSAGE_TOOLTIP"));
+
+  -- Lenses
   PopulateCheckBox(Controls.AutoapplyArchaeologistLensCheckbox, "CQUI_AutoapplyArchaeologistLens");
   PopulateCheckBox(Controls.AutoapplyBuilderLensCheckbox, "CQUI_AutoapplyBuilderLens");
   PopulateCheckBox(Controls.AutoapplyScoutLensCheckbox, "CQUI_AutoapplyScoutLens");
-  PopulateCheckBox(Controls.ShowNothingToDoInBuilderLens, "CQUI_ShowNothingToDoBuilderLens", Locale.Lookup("LOC_CQUI_LENSES_SHOWNOTHINGTODO_TOOLTIP"));
+  PopulateCheckBox(Controls.ShowNothingToDoInBuilderLens, "CQUI_ShowNothingToDoBuilderLens", Locale.Lookup("LOC_CQUI_LENSES_SHOWNOTHINGTODO_BUILDER_TOOLTIP"));
+  PopulateCheckBox(Controls.ShowGenericInBuilderLens, "CQUI_ShowGenericBuilderLens", Locale.Lookup("LOC_CQUI_LENSES_SHOWGENERIC_BUILDER_TOOLTIP"));
+
   PopulateCheckBox(Controls.ShowYieldsOnCityHoverCheckbox, "CQUI_ShowYieldsOnCityHover", Locale.Lookup("LOC_CQUI_CITYVIEW_SHOWYIELDSONCITYHOVER_TOOLTIP"));
   PopulateCheckBox(Controls.ShowCitizenIconsOnHoverCheckbox, "CQUI_ShowCitizenIconsOnCityHover", Locale.Lookup("LOC_CQUI_CITYVIEW_SHOWCITIZENICONSONHOVER_TOOLTIP"));
   PopulateCheckBox(Controls.ShowCityManageAreaOnHoverCheckbox, "CQUI_ShowCityManageAreaOnCityHover", Locale.Lookup("LOC_CQUI_CITYVIEW_SHOWCITYMANAGEONHOVER_TOOLTIP"));

--- a/Assets/cqui_settingselement.xml
+++ b/Assets/cqui_settingselement.xml
@@ -395,7 +395,10 @@
             <GridButton ID="AutoapplyScoutLensCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_LENSES_AUTOAPPLYSCOUTLENS"/>
           </Stack>
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
-            <GridButton ID="ShowNothingToDoInBuilderLens" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_LENSES_SHOWNOTHINGTODO"/>
+            <GridButton ID="ShowNothingToDoInBuilderLens" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_LENSES_SHOWNOTHINGTODO_BUILDER"/>
+          </Stack>
+          <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+            <GridButton ID="ShowGenericInBuilderLens" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_LENSES_SHOWGENERIC_BUILDER"/>
           </Stack>
         </Stack>
       </Container>

--- a/Integrations/ML/UI/minimappanel.lua
+++ b/Integrations/ML/UI/minimappanel.lua
@@ -2,7 +2,7 @@
 --  MINIMAP PANEL
 -- ===========================================================================
 include( "InstanceManager" );
-include( "Civ6Common.lua" );    -- GetCivilizationUniqueTraits, GetLeaderUniqueTraits
+include( "Civ6Common.lua" ); -- GetCivilizationUniqueTraits, GetLeaderUniqueTraits
 include( "SupportFunctions" );
 
 -- ===========================================================================
@@ -44,14 +44,14 @@ local AUTO_APPLY_ARCHEOLOGIST_LENS:boolean = true
 -- Should the scout lens auto apply, when a scout/ranger is selected.
 local AUTO_APPLY_SCOUT_LENS:boolean = true;
 
--- Show citizen management area when hovering over city plot
-local SHOW_CITIZEN_MANAGEMENT_ONHOVER:boolean = false;
-
--- Show citizen management area when managing citizens
+-- Show citizen management when managing citizens
 local SHOW_CITIZEN_MANAGEMENT_INSCREEN:boolean = true;
 
 -- Highlight nothing to do (red plots) in builder lens
-local SHOW_NOTHING_TODO_IN_BUILDER_LENS:boolean = false;
+local SHOW_NOTHING_TODO_IN_BUILDER_LENS:boolean = true;
+
+-- Highlight generic (white plots) in builder lens
+local SHOW_GENERIC_PLOTS_IN_BUILDER_LENS:boolean = true;
 
 local CITY_WORK_RANGE:number = 3;
 
@@ -107,7 +107,6 @@ local m_CityOverlapRange:number = 6;
 local m_CurrentCursorPlotID:number = -1;
 
 -- Citizen management lens variables
-local m_EnableCitizenManagementArea:boolean = true;
 local m_CitizenManagementOn:boolean = false;
 local m_FullClearAreaLens:boolean = true;
 local m_tAreaPlotsColored:table = {}
@@ -878,7 +877,7 @@ function SetWaterHexes()
       UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_WATER_AVAILABLITY, localPlayer, NoSettlePlots, DisgustingColor );
     end
 
-  else -- A settler is selected with ctrl down, show alternate highlighting
+  else -- A settler is selected, show alternate highlighting
     SetSettlerLens()
   end
 end
@@ -886,6 +885,8 @@ end
 function SetSettlerLens()
   -- If cursor is not on a plot, don't do anything
   local plotId = UI.GetCursorPlotID();
+
+    -- If Modal Panel, or cursor is not on a plot, show normal Water Hexes
   if (not Map.IsPlot(plotId)) then
     return
   end
@@ -1221,7 +1222,7 @@ function SetBuilderLensHexes()
   if table.count(featureHexes) > 0 then
     UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_APPEAL_LEVEL, localPlayer, featureHexes, FeatureColor );
   end
-  if table.count(genericHexes) > 0 then
+  if SHOW_GENERIC_PLOTS_IN_BUILDER_LENS and table.count(genericHexes) > 0 then
     UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_APPEAL_LEVEL, localPlayer, genericHexes, GenericColor );
   end
   if SHOW_NOTHING_TODO_IN_BUILDER_LENS and table.count(unworkableHexes) > 0 then
@@ -2234,19 +2235,6 @@ function HandleMouseForModdedLens( mousex:number, mousey:number )
       end
     end
 
-    if SHOW_CITIZEN_MANAGEMENT_ONHOVER and m_EnableCitizenManagementArea then
-
-      -- Cancel if unit is selected or Modal Lens Panel is out
-      if (selectedUnit == nil and UI.GetInterfaceMode() ~= InterfaceModeTypes.VIEW_MODAL_LENS) then
-        if pPlot:IsCity() and pPlot:GetOwner() == Game.GetLocalPlayer() then
-          RefreshCitizenManagementArea();
-        elseif m_CitizenManagementOn then
-          ClearAreaLens()
-          m_CitizenManagementOn = false
-        end
-      end
-    end
-
     -- Handler for alternate settler lens
     if m_CtrlDown then
       if selectedUnit ~= nil then
@@ -2368,7 +2356,6 @@ function IsAdjYieldWonder(featureInfo)
       end
     end
   end
-
   return false
 end
 
@@ -2379,7 +2366,6 @@ function plotNextToBuffingWonder(plot)
       return true
     end
   end
-
   return false
 end
 
@@ -2420,7 +2406,6 @@ function plotHasRecomFeature(plot)
       end
     end
   end
-
   return false
 end
 
@@ -2429,7 +2414,6 @@ function plotHasAnitquitySite(plot)
   if resourceInfo ~= nil and resourceInfo.ResourceType == "RESOURCE_ANTIQUITY_SITE" then
     return true;
   end
-
   return false
 end
 
@@ -3133,7 +3117,6 @@ function OnInterfaceModeChanged(eOldMode:number, eNewMode:number)
   if SHOW_CITIZEN_MANAGEMENT_INSCREEN then
     if eOldMode == InterfaceModeTypes.CITY_MANAGEMENT then
       ClearAreaLens()
-      m_EnableCitizenManagementArea = true;
       m_CitizenManagementOn = false
     end
 
@@ -3141,7 +3124,6 @@ function OnInterfaceModeChanged(eOldMode:number, eNewMode:number)
       local selectedCity = UI.GetHeadSelectedCity();
       if (selectedCity ~= nil) then
         RefreshCitizenManagementArea(selectedCity:GetID())
-        m_EnableCitizenManagementArea = false;
       end
     end
   end
@@ -3189,6 +3171,36 @@ function OnInterfaceModeChanged(eOldMode:number, eNewMode:number)
   end
 end
 
+function OnCitySelectionChanged(owner, ID, i, j, k, bSelected, bEditable)
+  if owner ~= Game.GetLocalPlayer() then
+    return
+  end
+
+  if SHOW_CITIZEN_MANAGEMENT_INSCREEN then
+    if bSelected and m_CurrentAreaLensOn == AREA_LENS_ID.CITIZEN_MANAGEMENT then
+      RefreshCitizenManagementArea(ID)
+    end
+  end
+end
+
+function OnCityWorkerChanged(ownerPlayerID:number, cityID:number)
+  if SHOW_CITIZEN_MANAGEMENT_INSCREEN and ownerPlayerID == Game.GetLocalPlayer() and
+      m_CurrentAreaLensOn == AREA_LENS_ID.CITIZEN_MANAGEMENT then
+    RefreshCitizenManagementArea(cityID)
+  end
+end
+
+function OnCityMadePurchase(owner:number, cityID:number, plotX:number, plotY:number, purchaseType, objectType)
+  if SHOW_CITIZEN_MANAGEMENT_INSCREEN and owner == Game.GetLocalPlayer() and
+      m_CurrentAreaLensOn == AREA_LENS_ID.CITIZEN_MANAGEMENT and
+      purchaseType == EventSubTypes.PLOT then
+
+    -- Add plot so that the plot is properly cleared
+    table.insert(m_tAreaPlotsColored, Map.GetPlotIndex(plotX, plotY))
+    RefreshCitizenManagementArea(cityID)
+  end
+end
+
 -- For modded lens on unit selection
 function OnUnitSelectionChanged( playerID:number, unitID:number, hexI:number, hexJ:number, hexK:number, bSelected:boolean, bEditable:boolean )
   if playerID == Game.GetLocalPlayer() then
@@ -3214,6 +3226,12 @@ function OnUnitSelectionChanged( playerID:number, unitID:number, hexI:number, he
           ClearSettlerLens();
         end
       end
+    end
+
+    -- If unit is selected and citizen management area was on, turn on selection interface mode.
+    -- Lens will cleared in the OnInterfaceModeChanged event
+    if SHOW_CITIZEN_MANAGEMENT_INSCREEN and m_CurrentAreaLensOn == AREA_LENS_ID.CITIZEN_MANAGEMENT then
+        UI.SetInterfaceMode(InterfaceModeTypes.SELECTION)
     end
   end
 end
@@ -3275,22 +3293,6 @@ function OnUnitMoved( playerID:number, unitID:number )
         ShowScoutLens();
       end
     end
-  end
-end
-
-function OnCityWorkerChanged(ownerPlayerID:number, cityID:number)
-  if SHOW_CITIZEN_MANAGEMENT_INSCREEN and ownerPlayerID == Game.GetLocalPlayer() then
-    RefreshCitizenManagementArea(cityID)
-  end
-    end
-
-function OnCityMadePurchase(owner:number, cityID:number, plotX:number, plotY:number, purchaseType, objectType)
-  if SHOW_CITIZEN_MANAGEMENT_INSCREEN and owner == Game.GetLocalPlayer()
-      and purchaseType == EventSubTypes.PLOT then
-
-    -- Add plot so that the plot is properly cleared
-    table.insert(m_tAreaPlotsColored, Map.GetPlotIndex(plotX, plotY))
-    RefreshCitizenManagementArea(cityID)
   end
 end
 
@@ -3508,6 +3510,7 @@ function Initialize()
   LuaEvents.MinimapPanel_RefreshMinimapOptions.Add( RefreshMinimapOptions );
 
   -- For modded lenses
+  Events.CitySelectionChanged.Add( OnCitySelectionChanged );
   Events.UnitSelectionChanged.Add( OnUnitSelectionChanged );
   Events.UnitCaptured.Add( OnUnitCaptured );
   Events.UnitChargesChanged.Add( OnUnitChargesChanged );
@@ -3536,5 +3539,4 @@ function Initialize()
   LuaEvents.Area_RefreshCitizenManagement.Add( RefreshCitizenManagementArea );
   LuaEvents.Area_ClearCitizenManagement.Add( ClearAreaLens );
 end
-
 Initialize();

--- a/Integrations/ML/UI/minimappanel.lua
+++ b/Integrations/ML/UI/minimappanel.lua
@@ -168,6 +168,7 @@ function CQUI_OnSettingsUpdate()
   AUTO_APPLY_SCOUT_LENS = GameConfiguration.GetValue("CQUI_AutoapplyScoutLens");
   SHOW_CITIZEN_MANAGEMENT_INSCREEN = GameConfiguration.GetValue("CQUI_ShowCityMangeAreaInScreen");
   SHOW_NOTHING_TODO_IN_BUILDER_LENS = GameConfiguration.GetValue("CQUI_ShowNothingToDoBuilderLens");
+  SHOW_GENERIC_PLOTS_IN_BUILDER_LENS = GameConfiguration.GetValue("CQUI_ShowGenericBuilderLens");
 
   --Cycles the minimap after resizing
   CQUI_UpdateMinimapSize();
@@ -3422,7 +3423,10 @@ function Initialize()
   m_MiniMap_xmloffsety = Controls.MiniMap:GetOffsetY();
   m_ContinentsCache = Map.GetContinentsInUse();
 
-  Controls.MinimapImage:RegisterSizeChanged( OnMinimapImageSizeChanged );
+  -- Check for function nil for backward compatibiliy. @Summer Patch 2017
+  if Controls.MinimapImage.RegisterSizeChanged ~= nil then
+    Controls.MinimapImage:RegisterSizeChanged( OnMinimapImageSizeChanged );
+  end
   UI.SetMinimapImageControl(Controls.MinimapImage);
   Controls.LensChooserList:CalculateSize();
 


### PR DESCRIPTION
### Bug fixes with More Lenses
1. Citizen Management area should be properly updated/removed when needed
1. Removed code from a deprecated feature
1. Linux and Mac backward compatibility
1. Adds a new setting for builder lens: Generic hexes can now be hidden.